### PR TITLE
Add installation script and README for Conserver vCon Server

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,82 @@
+# Conserver Installation Script
+
+A bash script to easily install and configure Conserver vCon Server with all necessary components.
+
+## Overview
+
+This script automates the installation process for the Conserver vCon Server, setting up:
+- Docker containers
+- MongoDB
+- Redis
+- vCon Server API
+- Admin interface
+- Traefik for routing
+
+## Quick Installation
+
+```bash
+curl -o install_conserver.sh https://raw.githubusercontent.com/your-username/your-repo/main/install_conserver.sh
+chmod +x install_conserver.sh
+sudo ./install_conserver.sh --domain your-domain.com --email your-email@example.com
+```
+
+## Requirements
+
+- Ubuntu Linux (recommended)
+- Root access
+- Public internet access
+- DNS record pointing to your server for the domain you specify
+
+## Usage Options
+
+```bash
+./install_conserver.sh [options]
+```
+
+### Required Parameters:
+- `-d, --domain DOMAIN` - Domain name for the installation
+- `-e, --email EMAIL` - Email for DNS registration and notifications
+
+### Optional Parameters:
+- `-t, --token TOKEN` - API token (default: randomly generated)
+- `-h, --help` - Display help information
+
+## Post-Installation
+
+After successful installation, you'll have access to:
+
+- **Admin Portal**: `https://your-domain.com/admin/` (default login: admin/admin)
+- **API Documentation**: `https://your-domain.com/api/docs`
+- **API Token**: Displayed at the end of installation (save this!)
+- **MongoDB Express**: `https://your-domain.com/mongo-express`
+- **Redis Stack**: `http://localhost:8001`
+
+## Configuration
+
+The script creates the following configuration:
+- Docker network named "conserver"
+- MongoDB for vCon storage
+- Redis for message queuing
+- Pipeline configuration with tags set to "conserver"
+
+## Troubleshooting
+
+If you encounter issues:
+
+1. Check Docker container status: `docker ps`
+2. Inspect Docker network: `docker network inspect conserver`
+3. View container logs: `docker logs [container-name]`
+
+## Security Notes
+
+- Change the default admin/admin credentials immediately after installation
+- The API token is displayed at the end of installation - save it securely
+- Consider restricting access to Redis on port 8001 if not needed externally
+
+## License
+
+This script is provided as-is under the same license as the Conserver vCon Server.
+
+## Contributing
+
+Feel free to submit issues or pull requests to improve this installation script.

--- a/scripts/install_conserver.sh
+++ b/scripts/install_conserver.sh
@@ -1,0 +1,244 @@
+#!/bin/bash
+
+# Conserver vCon Server Installation Script
+# Based on installation notes for conserver integration
+
+set -e
+
+# Function to display help message
+display_help() {
+    echo "Conserver vCon Server Installation Script"
+    echo ""
+    echo "Usage: $0 [options]"
+    echo ""
+    echo "Options:"
+    echo "  -d, --domain DOMAIN       Domain name for the installation (required)"
+    echo "  -e, --email EMAIL         Email for DNS registration (required)"
+    echo "  -t, --token TOKEN         API token (default: generates random token)"
+    echo "  -h, --help                Display this help message"
+    echo ""
+    exit 0
+}
+
+# Function to log messages
+log() {
+    echo "[$(date +'%Y-%m-%d %H:%M:%S')] $1"
+}
+
+# Function to check if command exists
+command_exists() {
+    command -v "$1" >/dev/null 2>&1
+}
+
+# Parse command line arguments
+RANDOM_TOKEN=$(openssl rand -hex 8)
+API_TOKEN=${RANDOM_TOKEN}
+
+while [[ $# -gt 0 ]]; do
+    key="$1"
+    case $key in
+        -d|--domain)
+            DOMAIN="$2"
+            shift 2
+            ;;
+        -e|--email)
+            EMAIL="$2"
+            shift 2
+            ;;
+        -t|--token)
+            API_TOKEN="$2"
+            shift 2
+            ;;
+        -h|--help)
+            display_help
+            shift
+            ;;
+        *)
+            echo "Unknown option: $1"
+            display_help
+            exit 1
+            ;;
+    esac
+done
+
+# Check for required parameters
+if [ -z "$DOMAIN" ]; then
+    echo "ERROR: Domain name is required. Use --domain to specify."
+    display_help
+    exit 1
+fi
+
+if [ -z "$EMAIL" ]; then
+    echo "ERROR: Email is required. Use --email to specify."
+    display_help
+    exit 1
+fi
+
+# Welcome message
+log "Starting Conserver vCon Server installation"
+log "Domain: $DOMAIN"
+log "Email: $EMAIL"
+log "API Token: $API_TOKEN"
+
+# Check if running as root
+if [ "$(id -u)" -ne 0 ]; then
+    log "ERROR: This script must be run as root"
+    exit 1
+fi
+
+# Install Docker if not already installed
+if ! command_exists docker; then
+    log "Installing Docker..."
+    apt-get update
+    apt-get install -y ca-certificates curl gnupg
+    install -m 0755 -d /etc/apt/keyrings
+    curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+    chmod a+r /etc/apt/keyrings/docker.gpg
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null
+    apt-get update
+    apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+    log "Docker installed successfully"
+else
+    log "Docker is already installed"
+fi
+
+# Install git if not already installed
+if ! command_exists git; then
+    log "Installing git..."
+    apt-get update
+    apt-get install -y git
+    log "Git installed successfully"
+else
+    log "Git is already installed"
+fi
+
+# Create the docker network
+log "Creating docker network 'conserver'..."
+docker network create conserver || log "Network already exists"
+
+# Clone vcon-admin repository
+log "Cloning vcon-admin repository..."
+cd /root
+git clone https://github.com/vcon-dev/vcon-admin
+cd vcon-admin/
+
+# Create .env file
+log "Creating .env file for vcon-admin..."
+cat > .env << EOF
+DNS_HOST=${DOMAIN}
+export DNS_REGISTRATION_EMAIL=${EMAIL}
+EOF
+
+# Create Streamlit secrets file
+log "Creating Streamlit secrets..."
+mkdir -p .streamlit
+cat > .streamlit/secrets.toml << EOF
+# .streamlit/secrets.toml
+
+[aws]
+AWS_DEFAULT_REGION = "us-east-1"
+AWS_ACCESS_KEY_ID=""
+AWS_SECRET_ACCESS_KEY=""
+
+[mongo_db]
+url = "mongodb://root:example@mongo:27017/"
+db = "conserver"
+collection = "vcons"
+
+[openai]
+testing_key = ""
+api_key = ""
+organization = ""
+project = ""
+vector_store_name = "vcons"
+assistant_id = ""
+
+[elasticsearch]
+url = "http://elasticsearch:9200"
+username = "elastic"
+password = ""
+
+[conserver]
+api_url = "https://${DOMAIN}/api"
+auth_token = "${API_TOKEN}"
+EOF
+
+# Build and start vcon-admin
+log "Building and starting vcon-admin..."
+docker compose up --build -d
+
+# Clone vcon-server repository
+log "Cloning vcon-server repository..."
+cd /root
+git clone https://github.com/vcon-dev/vcon-server
+cd vcon-server/
+
+# Create .env file
+log "Creating .env file for vcon-server..."
+cat > .env << EOF
+REDIS_URL=redis://redis
+
+# API security token
+CONSERVER_API_TOKEN=${API_TOKEN}
+
+# Custom configuration file
+CONSERVER_CONFIG_FILE=./config.yml
+
+# Groq API key for Whisper transcription
+GROQ_API_KEY=your_groq_api_key_here
+
+DNS_HOST=${DOMAIN}
+DNS_REGISTRATION_EMAIL=${EMAIL}
+EOF
+
+# Create config.yml
+log "Creating config.yml file..."
+cat > config.yml << EOF
+links:
+  tag:
+    module: links.tag
+    ingress-lists: []
+    egress-lists: []
+    options:
+      tags:
+      - conserver
+ 
+storages:
+  mongo:
+    module: storage.mongo
+    options:
+      url: mongodb://root:example@mongo:27017/
+      database: conserver
+      collection: vcons
+chains:
+  demo_chain:
+    ingress_lists:
+    - conserver_ingress
+    links:
+    - tag
+    storages:
+    - mongo
+    enabled: 1
+EOF
+
+# Build and start vcon-server
+log "Building and starting vcon-server..."
+docker compose up --build -d
+
+# Wait for services to start
+log "Waiting for services to start..."
+sleep 30
+
+# Display the installation summary
+log "Installation completed successfully!"
+log "-------------------------------------------------------"
+log "Portal Address: https://${DOMAIN}/admin/"
+log "Default login: admin/admin"
+log "SSH Access: root@${DOMAIN}"
+log "API Access: https://${DOMAIN}/api/docs"
+log "API Token: ${API_TOKEN}"
+log "Mongo Express Access: https://${DOMAIN}/mongo-express"
+log "Redis Stack Access: http://localhost:8001"
+log "-------------------------------------------------------"
+log "To check the running Docker containers, run: docker ps"
+log "To check the Docker network, run: docker network inspect conserver"


### PR DESCRIPTION
- Introduced a new bash script `install_conserver.sh` to automate the installation and configuration of Conserver vCon Server, including Docker, MongoDB, and Redis setup.
- Added a README file detailing the installation process, usage options, requirements, and post-installation access information.
- The script includes error handling, logging, and configuration file creation for both vCon Admin and vCon Server.