### PR TITLE
Add documentation for new vCon server links

### DIFF
--- a/server/links/README.md
+++ b/server/links/README.md
@@ -1,0 +1,53 @@
+# vCon Server Links
+
+This directory contains various link implementations for the vCon server. Each link provides specific functionality for processing and analyzing vCon data.
+
+## Available Links
+
+### analyze
+A powerful OpenAI-based analysis link that performs AI-powered analysis on vCon transcripts. Supports customizable analysis types, prompts, and models with configurable sampling and retry mechanisms.
+
+### analyze_vcon
+A specialized link that performs AI-powered analysis on entire vCon objects, returning structured JSON output. Unlike the standard analyze link, it processes the complete vCon structure rather than individual dialogs, with support for system prompts and JSON response validation.
+
+### datatrails
+A specialized link that integrates vCon data with the DataTrails platform, creating verifiable audit trails for vCon operations. Supports both asset-based and asset-free events, with automatic token management and structured event attributes mapping to SCITT envelopes.
+
+### deepgram
+A specialized link that performs speech-to-text transcription on audio recordings in vCon dialogs using the Deepgram API. Supports automatic language detection, confidence scoring, and minimum duration filtering for transcription quality.
+
+### diet
+A specialized link that helps reduce the size and content of vCon objects by selectively removing or modifying specific elements. Useful for data minimization, privacy protection, and optimizing storage with options for media redirection and system prompt removal.
+
+### expire_vcon
+A simple but effective link that sets an expiration time for vCon objects in Redis, enabling automatic cleanup after a specified period. Useful for data retention policy enforcement and storage optimization.
+
+### @groq_whisper
+A specialized link that performs speech-to-text transcription on audio recordings in vCon dialogs using Groq's implementation of the Whisper ASR service, with support for various audio formats and robust error handling.
+
+### @hugging_face_whisper
+A specialized link that performs speech-to-text transcription on audio recordings in vCon dialogs using Hugging Face's implementation of the Whisper ASR service, with support for various audio formats and robust error handling.
+
+### @hugging_llm_link
+A specialized link that performs AI-powered analysis on vCon transcripts using Hugging Face's language models, supporting both API-based and local model inference with configurable parameters and robust error handling.
+
+### @jq_link
+A specialized link that filters vCon objects using jq expressions, allowing for complex content-based filtering with configurable forwarding rules for matching or non-matching vCons.
+
+### @post_analysis_to_slack
+A specialized link that posts vCon analysis results to Slack channels, with support for team-specific notifications, conditional posting based on analysis content, and rich message formatting.
+
+### @sampler
+A specialized link that selectively processes vCons based on various sampling methods, including percentage, rate, modulo, and time-based sampling, enabling efficient resource utilization and focused analysis.
+
+### @scitt
+A specialized link that provides integrity and inclusion protection for vCon objects by creating and registering signed statements on a SCITT Transparency Service, ensuring vCons can be verified as authentic and complete.
+
+### @tag
+A simple link that adds configurable tags to vCon objects, enabling better organization and filtering of conversations.
+
+### @tag_router
+A specialized link that routes vCon objects to different Redis lists based on their tags, enabling flexible distribution of conversations to different processing queues or storage locations.
+
+### @webhook
+A specialized link that sends vCon objects to configured webhook URLs, enabling integration with external systems and event-driven workflows. 

--- a/server/links/analyze/README.md
+++ b/server/links/analyze/README.md
@@ -1,0 +1,79 @@
+# Analyze Link
+
+The Analyze link is a powerful plugin that performs AI-powered analysis on vCon transcripts using OpenAI's GPT models. It can generate various types of analysis, such as summaries, sentiment analysis, or any custom analysis based on the provided prompt.
+
+## Features
+
+- Flexible analysis types with customizable prompts
+- Support for OpenAI's GPT models (default: gpt-3.5-turbo-16k)
+- Configurable sampling rate for processing
+- Automatic retry mechanism with exponential backoff
+- Metrics tracking for analysis time and failures
+- Support for different source types and text locations
+
+## Configuration Options
+
+```python
+default_options = {
+    "prompt": "Summarize this transcript in a few sentences.",
+    "analysis_type": "summary",
+    "model": "gpt-3.5-turbo-16k",
+    "sampling_rate": 1,
+    "temperature": 0,
+    "source": {
+        "analysis_type": "transcript",
+        "text_location": "body.paragraphs.transcript",
+    },
+}
+```
+
+### Options Description
+
+- `prompt`: The instruction given to the AI model for analysis
+- `analysis_type`: The type of analysis to be performed (e.g., "summary", "sentiment")
+- `model`: The OpenAI model to use for analysis
+- `sampling_rate`: Rate at which vCons should be processed (0-1)
+- `temperature`: Controls randomness in the model's output (0-1)
+- `source`: Configuration for the input source
+  - `analysis_type`: Type of source analysis to use
+  - `text_location`: Path to the text content in the source analysis
+
+## Usage
+
+The link processes vCons by:
+1. Retrieving the vCon from Redis
+2. Applying configured filters and sampling
+3. For each dialog in the vCon:
+   - Retrieves the source text based on configuration
+   - Generates analysis using OpenAI
+   - Adds the analysis to the vCon
+4. Stores the updated vCon back in Redis
+
+## Error Handling
+
+- Implements retry logic with exponential backoff
+- Maximum of 6 retry attempts
+- Logs failures and tracks metrics for analysis failures
+
+## Metrics
+
+The link tracks the following metrics:
+- `conserver.link.openai.analysis_time`: Time taken for analysis
+- `conserver.link.openai.analysis_failures`: Count of analysis failures
+
+## Dependencies
+
+- OpenAI Python client
+- Tenacity for retry logic
+- Redis for vCon storage
+- Custom utilities:
+  - vcon_redis
+  - logging_utils
+  - metrics
+  - filters
+
+## Requirements
+
+- OpenAI API key must be provided in the options
+- Redis connection must be configured
+- Appropriate permissions for vCon access and storage 

--- a/server/links/analyze_vcon/README.md
+++ b/server/links/analyze_vcon/README.md
@@ -1,0 +1,79 @@
+# Analyze vCon Link
+
+The Analyze vCon link is a specialized plugin that performs AI-powered analysis on entire vCon objects using OpenAI's GPT models. Unlike the standard analyze link that processes individual dialogs, this link analyzes the complete vCon structure and returns structured JSON output.
+
+## Features
+
+- Whole vCon analysis with structured JSON output
+- Support for OpenAI's GPT models (default: gpt-3.5-turbo-16k)
+- Configurable system prompts for analysis context
+- Optional body property removal to optimize token usage
+- Automatic retry mechanism with exponential backoff
+- JSON response validation
+- Metrics tracking for analysis time and failures
+
+## Configuration Options
+
+```python
+default_options = {
+    "prompt": "Analyze this vCon and return a JSON object with your analysis.",
+    "analysis_type": "json_analysis",
+    "model": "gpt-3.5-turbo-16k",
+    "sampling_rate": 1,
+    "temperature": 0,
+    "system_prompt": "You are a helpful assistant that analyzes conversation data and returns structured JSON output.",
+    "remove_body_properties": True,
+}
+```
+
+### Options Description
+
+- `prompt`: The instruction given to the AI model for analysis
+- `analysis_type`: The type of analysis to be performed (e.g., "json_analysis")
+- `model`: The OpenAI model to use for analysis
+- `sampling_rate`: Rate at which vCons should be processed (0-1)
+- `temperature`: Controls randomness in the model's output (0-1)
+- `system_prompt`: Context-setting prompt for the AI model
+- `remove_body_properties`: Whether to remove body properties from dialogs to optimize token usage
+
+## Usage
+
+The link processes vCons by:
+1. Retrieving the vCon from Redis
+2. Applying configured filters and sampling
+3. Preparing the vCon data for analysis (optionally removing body properties)
+4. Generating analysis using OpenAI with JSON response format
+5. Validating the JSON response
+6. Adding the analysis to the vCon
+7. Storing the updated vCon back in Redis
+
+## Error Handling
+
+- Implements retry logic with exponential backoff
+- Maximum of 6 retry attempts
+- JSON response validation
+- Logs failures and tracks metrics for analysis failures
+
+## Metrics
+
+The link tracks the following metrics:
+- `conserver.link.openai.analysis_time`: Time taken for analysis
+- `conserver.link.openai.analysis_failures`: Count of analysis failures
+- `conserver.link.openai.invalid_json`: Count of invalid JSON responses
+
+## Dependencies
+
+- OpenAI Python client
+- Tenacity for retry logic
+- Redis for vCon storage
+- Custom utilities:
+  - vcon_redis
+  - logging_utils
+  - metrics
+  - filters
+
+## Requirements
+
+- OpenAI API key must be provided in the options
+- Redis connection must be configured
+- Appropriate permissions for vCon access and storage 

--- a/server/links/deepgram/README.md
+++ b/server/links/deepgram/README.md
@@ -1,0 +1,103 @@
+# Deepgram Link
+
+The Deepgram link is a specialized plugin that performs speech-to-text transcription on audio recordings in vCon dialogs using the Deepgram API. It supports automatic language detection and confidence scoring for transcription quality.
+
+## Features
+
+- Speech-to-text transcription using Deepgram's API
+- Automatic language detection
+- Confidence scoring for transcription quality
+- Minimum duration filtering for recordings
+- Automatic retry mechanism with exponential backoff
+- Metrics tracking for transcription time and failures
+- Support for URL-based audio sources
+
+## Configuration Options
+
+```python
+default_options = {
+    "minimum_duration": 60,  # Minimum duration in seconds for recordings to process
+    "DEEPGRAM_KEY": None,   # Your Deepgram API key
+    "api": {
+        # Deepgram API options
+        "model": "nova-2",
+        "language": "en",
+        "smart_format": True,
+        "punctuate": True,
+        "diarize": False,
+        "utterances": False,
+        "profanity_filter": False,
+        "redact": False,
+        "tier": "enhanced"
+    }
+}
+```
+
+### Options Description
+
+- `minimum_duration`: Minimum duration in seconds for recordings to process
+- `DEEPGRAM_KEY`: Your Deepgram API key
+- `api`: Deepgram API configuration options
+  - `model`: Deepgram model to use (e.g., "nova-2")
+  - `language`: Language code (e.g., "en")
+  - `smart_format`: Enable smart formatting
+  - `punctuate`: Enable punctuation
+  - `diarize`: Enable speaker diarization
+  - `utterances`: Enable utterance detection
+  - `profanity_filter`: Enable profanity filtering
+  - `redact`: Enable redaction
+  - `tier`: API tier to use (e.g., "enhanced")
+
+## Usage
+
+The link processes vCons by:
+1. Retrieving the vCon from Redis
+2. For each dialog in the vCon:
+   - Checking if it's a recording with a URL
+   - Verifying it meets the minimum duration requirement
+   - Checking if it's already transcribed
+   - Transcribing the audio using Deepgram
+   - Validating the transcription confidence
+   - Adding the transcription to the vCon
+3. Storing the updated vCon back in Redis
+
+## Transcription Output
+
+The transcription includes:
+- `transcript`: The transcribed text
+- `confidence`: Confidence score for the transcription
+- `detected_language`: Automatically detected language
+- `words`: Word-level details with timestamps
+- Additional metadata based on API options
+
+## Error Handling
+
+- Implements retry logic with exponential backoff
+- Maximum of 6 retry attempts
+- Logs failures and tracks metrics for transcription failures
+- Skips recordings with low confidence scores (< 0.5)
+
+## Metrics
+
+The link tracks the following metrics:
+- `conserver.link.deepgram.transcription_time`: Time taken for transcription
+- `conserver.link.deepgram.transcription_failures`: Count of transcription failures
+- `conserver.link.deepgram.confidence`: Confidence score of transcriptions
+
+## Dependencies
+
+- Deepgram Python client
+- Tenacity for retry logic
+- Redis for vCon storage
+- Custom utilities:
+  - vcon_redis
+  - logging_utils
+  - metrics
+  - error_tracking
+
+## Requirements
+
+- Deepgram API key must be provided in the options
+- Redis connection must be configured
+- Audio recordings must be accessible via URL
+- Appropriate permissions for vCon access and storage 

--- a/server/links/diet/README.md
+++ b/server/links/diet/README.md
@@ -1,0 +1,70 @@
+# Diet Link
+
+The Diet link is a specialized plugin that helps reduce the size and content of vCon objects by selectively removing or modifying specific elements. It's particularly useful for data minimization, privacy protection, and optimizing storage.
+
+## Features
+
+- Selective removal of dialog body content
+- Optional media redirection to external storage
+- Removal of analysis data
+- Filtering of attachments by MIME type
+- Removal of system prompts to prevent LLM instruction injection
+- In-place modification of vCon objects in Redis
+
+## Configuration Options
+
+```python
+default_options = {
+    "remove_dialog_body": False,  # Remove body content from dialogs
+    "post_media_to_url": "",      # URL endpoint to store media (if empty, media is just removed)
+    "remove_analysis": False,     # Remove all analysis data
+    "remove_attachment_types": [], # List of attachment types to remove (e.g., ["image/jpeg", "audio/mp3"])
+    "remove_system_prompts": False, # Remove system_prompt keys to prevent LLM instruction insertion
+}
+```
+
+### Options Description
+
+- `remove_dialog_body`: Whether to remove body content from dialogs
+- `post_media_to_url`: URL endpoint to store media content (if empty, media is just removed)
+- `remove_analysis`: Whether to remove all analysis data
+- `remove_attachment_types`: List of MIME types to remove from attachments
+- `remove_system_prompts`: Whether to remove system_prompt keys to prevent LLM instruction injection
+
+## Usage
+
+The link processes vCons by:
+1. Retrieving the vCon from Redis
+2. Applying configured modifications:
+   - Removing dialog body content (optionally posting to external URL)
+   - Removing analysis data if specified
+   - Filtering attachments by MIME type
+   - Removing system prompts if specified
+3. Storing the modified vCon back in Redis
+
+## Media Redirection
+
+When `post_media_to_url` is configured, the link will:
+1. Post the media content to the specified URL
+2. Replace the body content with the URL to the stored content
+3. Set the body_type to "url"
+4. If the post fails, the body content will be removed
+
+## Security Features
+
+- Recursive removal of system_prompt keys to prevent LLM instruction injection attacks
+- Selective removal of sensitive data types
+- Option to redirect media to secure storage
+
+## Dependencies
+
+- Redis for vCon storage
+- Requests library for media redirection
+- Custom utilities:
+  - logging_utils
+
+## Requirements
+
+- Redis connection must be configured
+- Appropriate permissions for vCon access and storage
+- If using media redirection, a valid endpoint URL must be provided 

--- a/server/links/expire_vcon/README.md
+++ b/server/links/expire_vcon/README.md
@@ -1,0 +1,54 @@
+# Expire vCon Link
+
+The Expire vCon link is a simple but effective plugin that sets an expiration time for vCon objects in Redis. This helps manage storage by automatically removing vCons after a specified period.
+
+## Features
+
+- Sets Redis expiration time for vCon objects
+- Configurable expiration duration
+- Simple and lightweight implementation
+- Automatic cleanup of expired vCons
+
+## Configuration Options
+
+```python
+default_options = {
+    "seconds": 60 * 60 * 24  # Default: 24 hours (86400 seconds)
+}
+```
+
+### Options Description
+
+- `seconds`: The number of seconds after which the vCon will expire and be automatically removed from Redis
+
+## Usage
+
+The link processes vCons by:
+1. Setting an expiration time on the vCon key in Redis
+2. Logging the expiration time setting
+3. Returning the vCon UUID to continue processing
+
+## Implementation Details
+
+The link uses Redis's built-in expiration mechanism:
+- The `EXPIRE` command sets a timeout on a key
+- After the timeout, Redis automatically removes the key
+- No additional cleanup processes are required
+
+## Dependencies
+
+- Redis for vCon storage
+- Custom utilities:
+  - logging_utils
+
+## Requirements
+
+- Redis connection must be configured
+- Appropriate permissions for vCon access and storage
+
+## Common Use Cases
+
+- Data retention policy enforcement
+- Automatic cleanup of temporary vCons
+- Storage optimization
+- Privacy compliance (GDPR, CCPA, etc.) 

--- a/server/links/groq_whisper/README.md
+++ b/server/links/groq_whisper/README.md
@@ -1,16 +1,85 @@
 # Groq Whisper Link
 
-A vCon-server link that provides automatic transcription of audio content using Groq's implementation of Whisper ASR.
+The Groq Whisper link is a specialized plugin that performs speech-to-text transcription on audio recordings in vCon dialogs using Groq's implementation of the Whisper ASR service. It provides high-quality transcription with support for various audio formats and robust error handling.
 
-## Overview
+## Features
 
-This link processes vCon objects containing audio recordings and transcribes them using Groq's Whisper API. The transcription results are added back to the vCon as analysis entries.
+- Speech-to-text transcription using Groq's Whisper service
+- Support for both inline and external audio files
+- File integrity verification with signature checking
+- Minimum duration filtering for recordings
+- Automatic retry mechanism with exponential backoff
+- Metrics tracking for transcription time and failures
+- Support for various audio formats (default: FLAC)
+
+## Configuration Options
+
+```python
+default_options = {
+    "minimum_duration": 30,  # Minimum duration in seconds for recordings to process
+    "API_KEY": os.environ.get("GROQ_API_KEY", "YOUR_GROQ_API_KEY"),  # Groq API key
+    "Content-Type": "audio/flac",  # Content type of the audio files
+}
+```
+
+### Options Description
+
+- `minimum_duration`: Minimum duration in seconds for recordings to process
+- `API_KEY`: Your Groq API key (should be set via environment variables)
+- `Content-Type`: MIME type of the audio files being processed
+
+## Usage
+
+The link processes vCons by:
+1. Retrieving the vCon from Redis
+2. For each dialog in the vCon:
+   - Checking if it's a recording with sufficient duration
+   - Verifying if it's already transcribed
+   - Retrieving the audio content (from inline body or external URL)
+   - Verifying file integrity if signature is provided
+   - Transcribing the audio using Groq's Whisper service
+   - Adding the transcription to the vCon
+3. Storing the updated vCon back in Redis
+
+## Transcription Output
+
+The transcription includes:
+- `text`: The transcribed text
+- Additional metadata from the Groq Whisper API response
+- Vendor schema with configuration details (excluding API key)
+
+## Error Handling
+
+- Implements retry logic with exponential backoff
+- Maximum of 6 retry attempts
+- File integrity verification
+- Logs failures and tracks metrics for transcription failures
+- Graceful handling of various error conditions
+
+## Metrics
+
+The link tracks the following metrics:
+- `conserver.link.groq_whisper.transcription_time`: Time taken for transcription
+- `conserver.link.groq_whisper.transcription_failures`: Count of transcription failures
+
+## Dependencies
+
+- Groq Python client
+- Requests library for external file retrieval
+- Tenacity for retry logic
+- Redis for vCon storage
+- Custom utilities:
+  - vcon_redis
+  - logging_utils
+  - metrics
+  - error_tracking
 
 ## Requirements
 
-- Python 3.12+
-- A valid Groq API key
-- The `groq` Python package
+- Groq API key must be provided (preferably via environment variables)
+- Redis connection must be configured
+- Audio recordings must be accessible (either inline or via URL)
+- Appropriate permissions for vCon access and storage
 
 ## Installation
 

--- a/server/links/hugging_face_whisper/README.md
+++ b/server/links/hugging_face_whisper/README.md
@@ -1,0 +1,83 @@
+# Hugging Face Whisper Link
+
+The Hugging Face Whisper link is a specialized plugin that performs speech-to-text transcription on audio recordings in vCon dialogs using Hugging Face's implementation of the Whisper ASR service. It provides high-quality transcription with support for various audio formats and robust error handling.
+
+## Features
+
+- Speech-to-text transcription using Hugging Face's Whisper service
+- Support for both inline and external audio files
+- File integrity verification with signature checking
+- Minimum duration filtering for recordings
+- Automatic retry mechanism with exponential backoff
+- Metrics tracking for transcription time and failures
+- Support for various audio formats (default: FLAC)
+
+## Configuration Options
+
+```python
+default_options = {
+    "minimum_duration": 30,  # Minimum duration in seconds for recordings to process
+    "API_URL": "https://xxxxxx.us-east-1.aws.endpoints.huggingface.cloud",  # Hugging Face API endpoint
+    "API_KEY": "Bearer hf_XXXXX",  # Hugging Face API key
+    "Content-Type": "audio/flac",  # Content type of the audio files
+}
+```
+
+### Options Description
+
+- `minimum_duration`: Minimum duration in seconds for recordings to process
+- `API_URL`: The Hugging Face API endpoint URL
+- `API_KEY`: Your Hugging Face API key (should be set via environment variables)
+- `Content-Type`: MIME type of the audio files being processed
+
+## Usage
+
+The link processes vCons by:
+1. Retrieving the vCon from Redis
+2. For each dialog in the vCon:
+   - Checking if it's a recording with sufficient duration
+   - Verifying if it's already transcribed
+   - Retrieving the audio content (from inline body or external URL)
+   - Verifying file integrity if signature is provided
+   - Transcribing the audio using Hugging Face's Whisper service
+   - Adding the transcription to the vCon
+3. Storing the updated vCon back in Redis
+
+## Transcription Output
+
+The transcription includes:
+- `text`: The transcribed text
+- Additional metadata from the Hugging Face Whisper API response
+- Vendor schema with configuration details (excluding API key)
+
+## Error Handling
+
+- Implements retry logic with exponential backoff
+- Maximum of 6 retry attempts
+- File integrity verification
+- Logs failures and tracks metrics for transcription failures
+- Graceful handling of various error conditions
+
+## Metrics
+
+The link tracks the following metrics:
+- `conserver.link.hugging_face_whisper.transcription_time`: Time taken for transcription
+- `conserver.link.hugging_face_whisper.transcription_failures`: Count of transcription failures
+
+## Dependencies
+
+- Requests library for API communication and external file retrieval
+- Tenacity for retry logic
+- Redis for vCon storage
+- Custom utilities:
+  - vcon_redis
+  - logging_utils
+  - metrics
+  - error_tracking
+
+## Requirements
+
+- Hugging Face API key must be provided (preferably via environment variables)
+- Redis connection must be configured
+- Audio recordings must be accessible (either inline or via URL)
+- Appropriate permissions for vCon access and storage 

--- a/server/links/jq_link/README.md
+++ b/server/links/jq_link/README.md
@@ -1,17 +1,80 @@
-# JQ Filter Link
+# JQ Link
 
-The JQ Filter link allows flexible filtering of vCons in a chain using jq expressions. It can be used to either forward or filter out vCons based on their content, enabling complex filtering logic within your vCon processing pipelines.
+The JQ link is a specialized plugin that filters vCon objects using jq expressions. It provides a powerful way to selectively process vCons based on their content, allowing for complex filtering conditions and flexible forwarding rules.
 
-## Overview
+## Features
 
-This link uses jq expressions to evaluate conditions against vCons. Based on whether the conditions match and the configuration, it will either forward the vCon down the chain or filter it out.
+- Filter vCons using jq expressions
+- Forward matching or non-matching vCons based on configuration
+- Support for complex JSON path expressions
+- Efficient filtering without modifying vCon content
+- Detailed logging of filter operations and results
+- Simple configuration with minimal dependencies
 
-### Key Features
+## Configuration Options
 
-- Uses jq expressions for flexible filtering
-- Can forward either matching or non-matching vCons
-- Configurable through standard link options
-- Detailed logging of filter decisions
+```python
+default_options = {
+    "filter": ".",  # jq filter expression to evaluate
+    "forward_matches": True,  # if True, forward vCons that match the filter
+}
+```
+
+### Options Description
+
+- `filter`: The jq filter expression to evaluate against the vCon
+- `forward_matches`: Boolean flag that determines whether to forward matching or non-matching vCons
+
+## Usage
+
+The link processes vCons by:
+1. Retrieving the vCon from Redis
+2. Converting the vCon to a dictionary for jq processing
+3. Applying the configured jq filter expression
+4. Determining whether to forward the vCon based on the filter results and `forward_matches` setting
+5. Returning the vCon UUID for forwarding or None for filtering
+
+## JQ Filter Examples
+
+Here are some common jq filter expressions:
+
+```jq
+# Match vCons with at least one dialog
+.filter: ".dialog | length > 0"
+
+# Match vCons with a specific participant
+.filter: ".participants[] | select(.name == \"John Doe\")"
+
+# Match vCons with a specific analysis type
+.filter: ".analysis[] | select(.type == \"transcript\")"
+
+# Match vCons with a specific dialog type
+.filter: ".dialog[] | select(.type == \"recording\")"
+
+# Match vCons with a specific duration
+.filter: ".dialog[] | select(.duration > 60)"
+```
+
+## Error Handling
+
+- Logs errors when applying jq filters
+- Returns None (filtering out the vCon) on filter errors
+- Provides detailed debug logging of filter operations
+- Graceful handling of malformed jq expressions
+
+## Dependencies
+
+- jq Python library
+- Redis for vCon storage
+- Custom utilities:
+  - vcon_redis
+  - logging_utils
+
+## Requirements
+
+- Redis connection must be configured
+- Appropriate permissions for vCon access and storage
+- Basic understanding of jq expressions for effective filtering
 
 ## Installation
 

--- a/server/links/post_analysis_to_slack/README.md
+++ b/server/links/post_analysis_to_slack/README.md
@@ -1,0 +1,82 @@
+# Post Analysis to Slack Link
+
+The Post Analysis to Slack link is a specialized plugin that posts vCon analysis results to Slack channels. It provides a way to notify teams about important analysis findings, with support for team-specific channels and customizable posting conditions.
+
+## Features
+
+- Post vCon analysis results to Slack channels
+- Support for team-specific notification channels
+- Conditional posting based on analysis type and content
+- Rich message formatting with buttons and links
+- Fallback to default channel for error handling
+- Tracking of posted analyses to prevent duplicates
+- Integration with dealer and team information
+
+## Configuration Options
+
+```python
+default_options = {
+    "token": None,  # Slack API token
+    "channel_name": None,  # Default Slack channel name
+    "url": "Url to hex sheet",  # URL for the details button
+    "analysis_to_post": "summary",  # Type of analysis to post
+    "only_if": {
+        "analysis_type": "customer_frustration",  # Analysis type to match
+        "includes": "NEEDS REVIEW"  # Text that must be included in the analysis
+    },
+}
+```
+
+### Options Description
+
+- `token`: Your Slack API token
+- `channel_name`: Default Slack channel for notifications
+- `url`: URL for the details button in the Slack message
+- `analysis_to_post`: Type of analysis to post (e.g., "summary")
+- `only_if`: Conditions that must be met for posting:
+  - `analysis_type`: Type of analysis to match
+  - `includes`: Text that must be included in the analysis body
+
+## Usage
+
+The link processes vCons by:
+1. Retrieving the vCon from Redis
+2. For each analysis in the vCon:
+   - Checking if it matches the posting conditions
+   - Verifying if it's already been posted to Slack
+   - Extracting team and dealer information
+   - Finding the corresponding summary analysis
+   - Posting to team-specific channel if applicable
+   - Posting to the default channel
+   - Marking the analysis as posted
+3. Storing the updated vCon back in Redis
+
+## Slack Message Format
+
+The link posts formatted messages to Slack with:
+- A section with a neutral face emoji
+- The analysis summary text
+- A button linking to the details URL
+- Team and dealer information when available
+
+## Error Handling
+
+- Posts to default channel if team channel doesn't exist
+- Logs errors when posting to Slack
+- Tracks posted analyses to prevent duplicates
+- Graceful handling of missing team or dealer information
+
+## Dependencies
+
+- Slack SDK for Python
+- Redis for vCon storage
+- Custom utilities:
+  - vcon_redis
+  - logging_utils
+
+## Requirements
+
+- Slack API token must be provided
+- Redis connection must be configured
+- Appropriate permissions for vCon access and storage
+- Slack workspace with configured channels 

--- a/server/links/sampler/README.md
+++ b/server/links/sampler/README.md
@@ -1,0 +1,94 @@
+# Sampler Link
+
+The Sampler link is a specialized plugin that selectively processes vCons based on various sampling methods. It provides a way to reduce the volume of vCons being processed in a chain, enabling efficient resource utilization and focused analysis.
+
+## Features
+
+- Multiple sampling methods for flexible vCon selection
+- Percentage-based sampling for proportional reduction
+- Rate-based sampling for time-controlled processing
+- Modulo-based sampling for consistent selection patterns
+- Time-based sampling for periodic processing
+- Configurable random seed for reproducible sampling
+- Efficient implementation with minimal dependencies
+
+## Configuration Options
+
+```python
+default_options = {
+    "method": "percentage",  # Sampling method to use
+    "value": 50,  # Value specific to the chosen method
+    "seed": None,  # Random seed for reproducible sampling
+}
+```
+
+### Options Description
+
+- `method`: The sampling method to use:
+  - `percentage`: Keep a percentage of vCons (0-100)
+  - `rate`: Keep vCons at a specific rate (seconds between samples)
+  - `modulo`: Keep every nth vCon
+  - `time_based`: Keep vCons at specific time intervals
+- `value`: The value specific to the chosen method
+- `seed`: Optional random seed for reproducible sampling
+
+## Usage
+
+The link processes vCons by:
+1. Determining the sampling method and parameters
+2. Applying the appropriate sampling function to the vCon UUID
+3. Returning the vCon UUID if it passes the sampling criteria
+4. Returning None to filter out the vCon if it doesn't pass
+
+## Sampling Methods
+
+### Percentage Sampling
+
+Keeps a specified percentage of vCons:
+```python
+# Keep 30% of vCons
+opts = {"method": "percentage", "value": 30}
+```
+
+### Rate Sampling
+
+Keeps vCons at a specific rate:
+```python
+# Keep one vCon every 5 seconds on average
+opts = {"method": "rate", "value": 5}
+```
+
+### Modulo Sampling
+
+Keeps every nth vCon based on a hash of the UUID:
+```python
+# Keep every 10th vCon
+opts = {"method": "modulo", "value": 10}
+```
+
+### Time-based Sampling
+
+Keeps vCons at specific time intervals:
+```python
+# Keep vCons every 60 seconds
+opts = {"method": "time_based", "value": 60}
+```
+
+## Error Handling
+
+- Validates sampling method before processing
+- Raises ValueError for unknown sampling methods
+- Graceful handling of invalid parameter values
+- Consistent behavior with reproducible results when seed is provided
+
+## Dependencies
+
+- Python standard library (random, time, hashlib)
+- Custom utilities:
+  - logging_utils
+
+## Requirements
+
+- No external dependencies required
+- Appropriate permissions for vCon access
+- Understanding of sampling methods for effective configuration 

--- a/server/links/scitt/readme.md
+++ b/server/links/scitt/readme.md
@@ -1,6 +1,96 @@
 # SCITT Link
 
-While vCons are authored, signed and stored in vCon services, assure integrity and inclusions protection through an implementation of [SCITT][scitt-architecture]
+The SCITT (Supply Chain Integrity, Transparency, and Trust) link is a specialized plugin that provides integrity and inclusion protection for vCon objects by creating and registering signed statements on a SCITT Transparency Service. It ensures that vCons can be verified as authentic and complete, protecting against tampering and deletion.
+
+## Features
+
+- Creates signed statements based on vCon data
+- Registers statements on a SCITT Transparency Service
+- Supports different vCon operations (create, update, delete)
+- Configurable signing keys and authentication
+- Integration with DataTrails SCITT implementation
+- Hash-based payload verification
+- OIDC authentication support
+
+## Configuration Options
+
+```python
+default_options = {
+    "client_id": "<set-in-config.yml>",  # DataTrails client ID
+    "client_secret": "<set-in-config.yml>",  # DataTrails client secret
+    "scrapi_url": "https://app.datatrails.ai/archivist/v2",  # SCITT Reference API URL
+    "auth_url": "https://app.datatrails.ai/archivist/iam/v1/appidp/token",  # Authentication URL
+    "signing_key_path": None,  # Path to the signing key file
+    "issuer": "ANONYMOUS CONSERVER",  # Issuer identifier
+    "vcon_operation": "vcon-create",  # Operation type to record
+    "key_id": None,  # Key ID for signing
+    "OIDC_flow": "client-credentials"  # OIDC authentication flow
+}
+```
+
+### Options Description
+
+- `client_id`: Your DataTrails client ID
+- `client_secret`: Your DataTrails client secret
+- `scrapi_url`: URL for the SCITT Reference API
+- `auth_url`: URL for authentication
+- `signing_key_path`: Path to the signing key file
+- `issuer`: Identifier for the statement issuer
+- `vcon_operation`: Type of vCon operation being recorded
+- `key_id`: Key ID for signing the statement
+- `OIDC_flow`: OIDC authentication flow to use
+
+## Usage
+
+The link processes vCons by:
+1. Retrieving the vCon from Redis
+2. Creating a signed statement based on the vCon data:
+   - Setting the subject to the vCon identifier
+   - Creating metadata with the vCon operation
+   - Using the vCon hash as the payload
+   - Signing the statement with the provided key
+3. Registering the signed statement on the SCITT service:
+   - Authenticating with the SCITT service
+   - Submitting the signed statement
+   - Receiving an operation ID for tracking
+4. Returning the vCon UUID for further processing
+
+## Signed Statement Format
+
+The signed statement includes:
+- Issuer information
+- Subject (vCon identifier)
+- Metadata (vCon operation)
+- Payload (vCon hash)
+- Signature using the provided key
+- Hash algorithm information
+- Content type information
+
+## Error Handling
+
+- Validates required configuration options
+- Handles missing vCon objects
+- Supports different OIDC authentication flows
+- Logs detailed information about the process
+- Raises appropriate HTTP exceptions for errors
+
+## Dependencies
+
+- Requests library for API communication
+- Custom utilities:
+  - vcon_redis
+  - logging_utils
+  - create_hashed_signed_statement
+  - register_signed_statement
+
+## Requirements
+
+- Python 3.7+
+- Access to a SCITT implementation (e.g., DataTrails)
+- DataTrails API credentials
+- Signing key for statement creation
+- Redis connection for vCon storage
+- Appropriate permissions for vCon access and SCITT service
 
 ## Overview
 
@@ -29,10 +119,6 @@ Setting the `vcon_operation` chain configuration, log different types of Events,
    ```bash
    pip install requests
    ```
-
-## Usage
-
-The SCITT Link will automatically process vCons as they pass through the conserver providing integrity protection on the processed vCon.
 
 ## Configuration
 

--- a/server/links/tag/README.md
+++ b/server/links/tag/README.md
@@ -1,0 +1,56 @@
+# Tag Link
+
+The Tag link is a specialized plugin that adds tags to vCon objects. It provides a simple way to categorize and organize vCons with custom tags, enabling better filtering, searching, and organization of conversation data.
+
+## Features
+
+- Add multiple tags to vCon objects
+- Simple configuration with tag list
+- In-place modification of vCon objects
+- Efficient tag management
+- Minimal dependencies
+- Seamless integration with vCon processing chains
+
+## Configuration Options
+
+```python
+default_options = {
+    "tags": ["iron", "maiden"],  # List of tags to add to the vCon
+}
+```
+
+### Options Description
+
+- `tags`: A list of tag names to add to the vCon. Each tag is added with the same name as both the tag name and value.
+
+## Usage
+
+The link processes vCons by:
+1. Retrieving the vCon from Redis
+2. Adding each configured tag to the vCon
+3. Storing the updated vCon back in Redis
+4. Returning the vCon UUID for further processing
+
+## Tag Format
+
+Tags are added to the vCon with:
+- Tag name: The string from the tags list
+- Tag value: The same string as the tag name
+
+## Error Handling
+
+- Graceful handling of missing tags configuration
+- Logs debug information about the process
+- Continues processing even if some tags fail to be added
+
+## Dependencies
+
+- Redis for vCon storage
+- Custom utilities:
+  - vcon_redis
+  - logging_utils
+
+## Requirements
+
+- Redis connection must be configured
+- Appropriate permissions for vCon access and storage 

--- a/server/links/tag_router/README.md
+++ b/server/links/tag_router/README.md
@@ -1,0 +1,75 @@
+# Tag Router Link
+
+The Tag Router link is a specialized plugin that routes vCon objects to different Redis lists based on their tags. It provides a flexible way to organize and distribute vCons to different processing queues or storage locations based on their tag content.
+
+## Features
+
+- Route vCons to different Redis lists based on tag content
+- Support for multiple tag formats (list and dictionary)
+- Configurable forwarding behavior
+- Flexible tag-based routing rules
+- Efficient Redis list management
+- Seamless integration with vCon processing chains
+
+## Configuration Options
+
+```python
+default_options = {
+    "tag_routes": {
+        "important": "important_vcons",  # Route vCons with "important" tag to "important_vcons" list
+        "urgent": "urgent_vcons"        # Route vCons with "urgent" tag to "urgent_vcons" list
+    },
+    "forward_original": True  # Whether to continue normal processing after routing
+}
+```
+
+### Options Description
+
+- `tag_routes`: A dictionary mapping tag names to target Redis list names. When a vCon has a tag matching a key in this dictionary, its UUID will be pushed to the corresponding Redis list.
+- `forward_original`: A boolean indicating whether to continue normal processing after routing. If False, the link will return None to stop further processing.
+
+## Usage
+
+The link processes vCons by:
+1. Retrieving the vCon from Redis
+2. Extracting tags from attachments
+3. Matching tags against configured routes
+4. Pushing vCon UUIDs to appropriate Redis lists
+5. Optionally continuing normal processing
+
+## Tag Format
+
+The link supports two tag formats in attachments:
+1. List format: `["tag_name:value", "another_tag:value"]`
+2. Dictionary format: `{"tag_name": "value", "another_tag": "value"}`
+
+In both cases, only the tag name (before the colon in list format, or the key in dictionary format) is used for routing.
+
+## Error Handling
+
+- Graceful handling of missing tag routes configuration
+- Logs debug information about the routing process
+- Continues processing even if some tags don't have matching routes
+- Proper handling of missing or malformed tags
+
+## Dependencies
+
+- Redis for vCon storage and list management
+- Custom utilities:
+  - vcon_redis
+  - logging_utils
+
+## Requirements
+
+- Redis connection must be configured
+- Appropriate permissions for vCon access and storage
+- Tags must be present in vCon attachments
+- Target Redis lists must be accessible
+
+## Common Use Cases
+
+- Distributing vCons to different processing queues based on priority
+- Organizing vCons into category-specific lists
+- Implementing tag-based workflow routing
+- Creating separate storage locations for different types of conversations
+- Building tag-based notification systems 

--- a/server/links/webhook/README.md
+++ b/server/links/webhook/README.md
@@ -1,0 +1,77 @@
+# Webhook Link
+
+The Webhook link is a specialized plugin that sends vCon objects to configured webhook URLs. It provides a flexible way to integrate vCon processing with external systems by forwarding vCon data to specified endpoints.
+
+## Features
+
+- Send vCon objects to multiple webhook URLs
+- Configurable authentication headers
+- API token support
+- JSON payload formatting
+- Response logging
+- Seamless integration with vCon processing chains
+
+## Configuration Options
+
+```python
+default_options = {
+    "webhook-urls": ["https://example.com/webhook"],  # List of webhook URLs to send vCons to
+    "auth_header": "Bearer your-auth-token",          # Authorization header value
+    "api_token": "your-api-token"                     # API token for x-conserver-api-token header
+}
+```
+
+### Options Description
+
+- `webhook-urls`: A list of URLs where vCon data will be sent. The link will attempt to send the vCon to each URL in the list.
+- `auth_header`: The value for the Authorization header in the webhook requests.
+- `api_token`: The value for the x-conserver-api-token header in the webhook requests.
+
+## Usage
+
+The link processes vCons by:
+1. Retrieving the vCon from Redis
+2. Converting the vCon to a JSON dictionary
+3. Sending POST requests to each configured webhook URL
+4. Logging the response from each webhook
+5. Continuing normal processing by returning the vCon UUID
+
+## Request Format
+
+The webhook requests include:
+- HTTP Method: POST
+- Content-Type: application/json
+- Headers:
+  - Authorization: Configured auth_header value
+  - x-conserver-api-token: Configured api_token value
+- Body: JSON representation of the vCon object
+
+## Error Handling
+
+- Logs debug information about the webhook process
+- Logs response status codes and text from webhook endpoints
+- Continues processing even if some webhook requests fail
+- Maintains vCon processing chain by returning the vCon UUID
+
+## Dependencies
+
+- Redis for vCon storage
+- Requests library for HTTP communication
+- Custom utilities:
+  - vcon_redis
+  - logging_utils
+
+## Requirements
+
+- Redis connection must be configured
+- Appropriate permissions for vCon access and storage
+- Webhook URLs must be accessible
+- Valid authentication credentials for webhook endpoints
+
+## Common Use Cases
+
+- Integrating vCon processing with external systems
+- Building event-driven workflows
+- Creating notification systems
+- Implementing data synchronization
+- Setting up monitoring and analytics pipelines 


### PR DESCRIPTION
- Introduced README files for various specialized links including analyze, analyze_vcon, datatrails, deepgram, diet, expire_vcon, groq_whisper, hugging_face_whisper, jq_link, post_analysis_to_slack, sampler, scitt, tag, tag_router, webhook.
- Each README outlines features, configuration options, usage, error handling, dependencies, and requirements for the respective links, enhancing clarity and usability for developers.
- This update aims to improve the overall documentation and facilitate easier integration and understanding of the vCon server's capabilities.