### PR TITLE
Add ingress-specific API key authentication and external API endpoint

### DIFF
--- a/example_config.yml
+++ b/example_config.yml
@@ -1,4 +1,26 @@
 ---
+# Ingress-specific API key authentication
+# This section defines API keys that are authorized to push vCons to specific ingress lists
+# Each key grants access only to the specified ingress list, providing secure isolation
+# Multiple API keys can be configured per ingress list for different clients/systems
+ingress_auth:
+  # Single API key for the 'customer_data' ingress list
+  customer_data: "customer-api-key-12345"
+
+  # Multiple API keys for the 'support_calls' ingress list (different clients)
+  support_calls:
+    - "support-api-key-67890"
+    - "support-client-2-key"
+    - "support-vendor-key-xyz"
+
+  # Multiple API keys for the 'sales_leads' ingress list
+  sales_leads:
+    - "sales-api-key-abcdef"
+    - "sales-partner-key-123"
+
+  # Single API key using string format (backward compatible)
+  analytics_data: "analytics-api-key-789"
+
 # Optional imports section for dynamically installed modules
 imports:
   # Example of importing a PyPI package

--- a/server/README_CORE.md
+++ b/server/README_CORE.md
@@ -46,8 +46,26 @@ The configuration system provides:
 - Storage configuration management
 - Follower configuration management
 - Import configuration management
+- Ingress authentication configuration for external API access
 
-### 3. Redis Queue Management (`redis_mgr.py`)
+### 3. API Layer (`api.py`)
+
+The API layer provides HTTP endpoints for vCon submission and management:
+- RESTful API endpoints using FastAPI
+- Authentication and authorization mechanisms
+- Internal vCon submission (`/vcon`) with full system access
+- External partner submission (`/vcon/external-ingress`) with scoped access
+- API key validation and ingress-specific access control
+- Request validation and error handling
+
+#### Key Features
+- **Multi-tier Authentication**: Different API keys for internal vs external access
+- **Scoped Authorization**: External API keys limited to specific ingress lists
+- **Input Validation**: Automatic vCon schema validation
+- **Error Handling**: Comprehensive HTTP error responses
+- **Logging**: Detailed request and processing logging
+
+### 4. Redis Queue Management (`redis_mgr.py`)
 
 The Redis management system provides:
 - Connection pool management
@@ -59,8 +77,11 @@ The Redis management system provides:
 ## Processing Flow
 
 1. **Ingress**
-   - vCons enter through configured ingress queues
+   - vCons enter through multiple pathways:
+     - **API Endpoints**: HTTP submission via `/vcon` (internal) or `/vcon/external-ingress` (external partners)
+     - **Queue Processing**: Direct ingress queue processing for automated workflows
    - Each ingress queue is mapped to a specific processing chain
+   - API submissions are authenticated and automatically queued to specified ingress lists
 
 2. **Chain Processing**
    - vCons are processed through configured links in sequence
@@ -75,11 +96,37 @@ The Redis management system provides:
    - Processed vCons are forwarded to configured egress queues
    - Multiple egress queues can be configured per chain
 
+## Authentication and Authorization
+
+The system implements multi-tier authentication and authorization:
+
+### API Authentication
+- **Header-based Authentication**: Uses `x-conserver-api-token` header
+- **Internal API Keys**: Full system access for internal operations
+- **External API Keys**: Scoped access limited to specific ingress lists
+
+### Authorization Levels
+1. **Internal Access**: Full system access with main API token
+   - Access to all API endpoints
+   - Full vCon retrieval and management capabilities
+   - System configuration access
+
+2. **External Partner Access**: Limited scope via `ingress_auth` configuration
+   - Access only to `/vcon/external-ingress` endpoint
+   - Restricted to pre-configured ingress lists
+   - No access to existing vCon data or system resources
+
+### Configuration-Based Access Control
+- External API keys are configured in `config.yml` under `ingress_auth`
+- Supports single or multiple API keys per ingress list
+- Provides secure isolation between different external partners
+
 ## Error Handling
 
 The system implements comprehensive error handling:
 - Link-level error tracking
 - Storage operation error handling
+- API authentication and authorization errors
 - Graceful shutdown support
 - Dead Letter Queue (DLQ) for failed processing
 
@@ -100,12 +147,28 @@ The system is configured through a YAML file that defines:
 - Storage backends
 - Queue mappings
 - Processing timeouts
+- External API authentication (`ingress_auth`)
+
+### Ingress Authentication Configuration
+The `ingress_auth` section configures external partner access:
+```yaml
+ingress_auth:
+  # Single API key per ingress list
+  customer_data: "api-key-123"
+  
+  # Multiple API keys per ingress list
+  support_calls:
+    - "partner1-key"
+    - "partner2-key"
+```
 
 ## Dependencies
 
 Core dependencies include:
-- Redis for queue management
-- PyYAML for configuration
+- Redis for queue management and vCon storage
+- FastAPI for HTTP API endpoints and request handling
+- PyYAML for configuration management
+- Pydantic for data validation and serialization
 - Custom storage backends
 - Processing link modules
 
@@ -129,4 +192,17 @@ Core dependencies include:
 4. **Queue Management**
    - Monitor queue lengths
    - Configure appropriate DLQs
-   - Handle queue processing errors 
+   - Handle queue processing errors
+
+5. **API Security**
+   - Use strong, unique API keys for external partners
+   - Rotate API keys regularly for security
+   - Configure minimal necessary access per ingress list
+   - Monitor API usage and authentication attempts
+   - Implement rate limiting for external endpoints
+
+6. **Authentication Configuration**
+   - Separate internal and external API keys
+   - Use configuration-based access control
+   - Document API key assignments and permissions
+   - Test authentication scenarios thoroughly 

--- a/server/api.py
+++ b/server/api.py
@@ -185,6 +185,7 @@ app.add_middleware(
 )
 
 api_router = APIRouter()
+external_router = APIRouter()
 
 
 class Vcon(BaseModel):
@@ -567,7 +568,7 @@ async def post_vcon(
         raise HTTPException(status_code=500, detail="Failed to store vCon")
 
 
-@api_router.post(
+@external_router.post(
     "/vcon/external-ingress",
     status_code=204,
     summary="Submit external vCon from 3rd party systems",
@@ -922,3 +923,6 @@ app.include_router(
     api_router,
     dependencies=[Security(get_api_key, scopes=[])]
 )
+
+# Include external router without main API authentication
+app.include_router(external_router)

--- a/server/config.py
+++ b/server/config.py
@@ -31,3 +31,15 @@ class Configuration:
     def get_imports(cls) -> dict:
         config = cls.get_config()
         return config.get("imports", {})
+
+    @classmethod
+    def get_ingress_auth(cls) -> dict:
+        """Get ingress-specific API key configuration.
+
+        Returns:
+            dict: Dictionary mapping ingress list names to their API keys.
+                  Values can be either a single string (one API key) or
+                  a list of strings (multiple API keys for the same ingress list).
+        """
+        config = cls.get_config()
+        return config.get("ingress_auth", {})

--- a/server/tests/test_external_ingress.py
+++ b/server/tests/test_external_ingress.py
@@ -1,0 +1,325 @@
+"""Unit tests for the external ingress API endpoint."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import api
+from fastapi.testclient import TestClient
+from settings import CONSERVER_HEADER_NAME
+from vcon_fixture import generate_mock_vcon
+
+
+class TestExternalIngress:
+    """Test cases for the /vcon/external-ingress endpoint."""
+
+    def setup_method(self):
+        """Set up test fixtures."""
+        self.client = TestClient(api.app)
+        self.test_vcon = generate_mock_vcon()
+        self.ingress_list = "test_external_ingress"
+        self.valid_api_key = "external-partner-key-123"
+        self.invalid_api_key = "invalid-key"
+
+    def test_validate_ingress_api_key_function(self):
+        """Test the validate_ingress_api_key function directly."""
+
+        with patch("config.Configuration.get_ingress_auth") as mock_get_ingress_auth:
+            # Test successful validation with single API key
+            mock_get_ingress_auth.return_value = {self.ingress_list: self.valid_api_key}
+
+            result = api.validate_ingress_api_key(self.ingress_list, self.valid_api_key)
+            assert result == self.valid_api_key
+
+            # Test successful validation with multiple API keys
+            mock_get_ingress_auth.return_value = {
+                self.ingress_list: [self.valid_api_key, "other-key"]
+            }
+
+            result = api.validate_ingress_api_key(self.ingress_list, self.valid_api_key)
+            assert result == self.valid_api_key
+
+    @patch("config.Configuration.get_ingress_auth")
+    @patch("api.add_vcon_to_set")
+    @patch("api.index_vcon")
+    def test_successful_submission_single_api_key(
+        self, mock_index_vcon, mock_add_vcon_to_set, mock_get_ingress_auth
+    ):
+        """Test successful vCon submission with single API key configuration."""
+        # Configure mocks
+        mock_get_ingress_auth.return_value = {self.ingress_list: self.valid_api_key}
+
+        # Mock Redis client properly
+        mock_redis = MagicMock()
+        mock_json = MagicMock()
+        mock_json.set = AsyncMock()
+        mock_redis.json.return_value = mock_json
+        mock_redis.rpush = AsyncMock()
+
+        # Set the global redis_async directly in the api module
+        api.redis_async = mock_redis
+
+        try:
+            # Make request
+            response = self.client.post(
+                f"/vcon/external-ingress?ingress_list={self.ingress_list}",
+                json=self.test_vcon,
+                headers={CONSERVER_HEADER_NAME: self.valid_api_key},
+            )
+
+            # Debug the response if it fails
+            if response.status_code != 204:
+                print(f"Status: {response.status_code}")
+                print(f"Response: {response.json()}")
+
+            # Assertions
+            assert response.status_code == 204
+            assert response.content == b""  # No content returned
+
+            # Verify Redis operations were called
+            mock_json.set.assert_called_once()
+            mock_redis.rpush.assert_called_once_with(
+                self.ingress_list, self.test_vcon["uuid"]
+            )
+            mock_add_vcon_to_set.assert_called_once()
+            mock_index_vcon.assert_called_once()
+
+        finally:
+            # Clean up the global variable
+            api.redis_async = None
+
+    @patch("config.Configuration.get_ingress_auth")
+    @patch("api.add_vcon_to_set")
+    @patch("api.index_vcon")
+    def test_successful_submission_multiple_api_keys(
+        self, mock_index_vcon, mock_add_vcon_to_set, mock_get_ingress_auth
+    ):
+        """Test successful vCon submission with multiple API keys for same ingress."""
+        # Configure mocks - multiple API keys for same ingress list
+        mock_get_ingress_auth.return_value = {
+            self.ingress_list: ["partner-1-key", self.valid_api_key, "partner-3-key"]
+        }
+
+        # Mock Redis client properly
+        mock_redis = MagicMock()
+        mock_json = MagicMock()
+        mock_json.set = AsyncMock()
+        mock_redis.json.return_value = mock_json
+        mock_redis.rpush = AsyncMock()
+
+        # Set the global redis_async directly in the api module
+        api.redis_async = mock_redis
+
+        try:
+            # Make request with one of the valid keys
+            response = self.client.post(
+                f"/vcon/external-ingress?ingress_list={self.ingress_list}",
+                json=self.test_vcon,
+                headers={CONSERVER_HEADER_NAME: self.valid_api_key},
+            )
+
+            # Assertions
+            assert response.status_code == 204
+            mock_redis.rpush.assert_called_once_with(
+                self.ingress_list, self.test_vcon["uuid"]
+            )
+
+        finally:
+            # Clean up the global variable
+            api.redis_async = None
+
+    @patch("config.Configuration.get_ingress_auth")
+    def test_invalid_api_key_single_config(self, mock_get_ingress_auth):
+        """Test rejection with invalid API key for single key configuration."""
+        mock_get_ingress_auth.return_value = {self.ingress_list: self.valid_api_key}
+
+        response = self.client.post(
+            f"/vcon/external-ingress?ingress_list={self.ingress_list}",
+            json=self.test_vcon,
+            headers={CONSERVER_HEADER_NAME: self.invalid_api_key},
+        )
+
+        assert response.status_code == 403
+        assert "Invalid API Key" in response.json()["detail"]
+
+    @patch("config.Configuration.get_ingress_auth")
+    def test_invalid_api_key_multiple_config(self, mock_get_ingress_auth):
+        """Test rejection with invalid API key for multiple key configuration."""
+        mock_get_ingress_auth.return_value = {
+            self.ingress_list: ["key1", "key2", "key3"]
+        }
+
+        response = self.client.post(
+            f"/vcon/external-ingress?ingress_list={self.ingress_list}",
+            json=self.test_vcon,
+            headers={CONSERVER_HEADER_NAME: self.invalid_api_key},
+        )
+
+        assert response.status_code == 403
+        assert "Invalid API Key" in response.json()["detail"]
+
+    @patch("config.Configuration.get_ingress_auth")
+    def test_unauthorized_ingress_list(self, mock_get_ingress_auth):
+        """Test rejection when API key is valid but not for requested ingress list."""
+        mock_get_ingress_auth.return_value = {
+            "authorized_ingress": self.valid_api_key,
+            "other_ingress": "other-key",
+        }
+
+        response = self.client.post(
+            f"/vcon/external-ingress?ingress_list=unauthorized_ingress",
+            json=self.test_vcon,
+            headers={CONSERVER_HEADER_NAME: self.valid_api_key},
+        )
+
+        assert response.status_code == 403
+        assert "not configured" in response.json()["detail"]
+
+    @patch("config.Configuration.get_ingress_auth")
+    def test_missing_api_key(self, mock_get_ingress_auth):
+        """Test rejection when no API key is provided."""
+        mock_get_ingress_auth.return_value = {self.ingress_list: self.valid_api_key}
+
+        response = self.client.post(
+            f"/vcon/external-ingress?ingress_list={self.ingress_list}",
+            json=self.test_vcon,
+            # No API key header
+        )
+
+        assert response.status_code == 403
+        # The actual error message when no API key is provided
+        error_detail = response.json()["detail"]
+        assert "Invalid API Key" in error_detail or "API Key required" in error_detail
+
+    @patch("config.Configuration.get_ingress_auth")
+    def test_no_ingress_auth_configured(self, mock_get_ingress_auth):
+        """Test rejection when no ingress authentication is configured."""
+        mock_get_ingress_auth.return_value = {}
+
+        response = self.client.post(
+            f"/vcon/external-ingress?ingress_list={self.ingress_list}",
+            json=self.test_vcon,
+            headers={CONSERVER_HEADER_NAME: self.valid_api_key},
+        )
+
+        assert response.status_code == 403
+        assert "No ingress authentication configured" in response.json()["detail"]
+
+    @patch("config.Configuration.get_ingress_auth")
+    def test_invalid_config_format(self, mock_get_ingress_auth):
+        """Test handling of invalid configuration format (not string or list)."""
+        mock_get_ingress_auth.return_value = {
+            self.ingress_list: {"invalid": "format"}  # Neither string nor list
+        }
+
+        response = self.client.post(
+            f"/vcon/external-ingress?ingress_list={self.ingress_list}",
+            json=self.test_vcon,
+            headers={CONSERVER_HEADER_NAME: self.valid_api_key},
+        )
+
+        assert response.status_code == 403
+        assert "Invalid configuration" in response.json()["detail"]
+
+    @patch("config.Configuration.get_ingress_auth")
+    def test_redis_failure_handling(self, mock_get_ingress_auth):
+        """Test error handling when Redis operations fail."""
+        mock_get_ingress_auth.return_value = {self.ingress_list: self.valid_api_key}
+
+        # Mock Redis client that fails (use MagicMock to avoid coroutine issues)
+        mock_redis = MagicMock()
+        mock_json = MagicMock()
+        mock_json.set = AsyncMock(side_effect=Exception("Redis connection failed"))
+        mock_redis.json.return_value = mock_json
+        mock_redis.rpush = AsyncMock()
+
+        # Set the global redis_async directly in the api module
+        api.redis_async = mock_redis
+
+        try:
+            response = self.client.post(
+                f"/vcon/external-ingress?ingress_list={self.ingress_list}",
+                json=self.test_vcon,
+                headers={CONSERVER_HEADER_NAME: self.valid_api_key},
+            )
+
+            assert response.status_code == 500
+            assert "Failed to store vCon" in response.json()["detail"]
+
+        finally:
+            # Clean up the global variable
+            api.redis_async = None
+
+    @patch("config.Configuration.get_ingress_auth")
+    @patch("api.add_vcon_to_set")
+    @patch("api.index_vcon")
+    def test_multiple_ingress_lists_isolation(
+        self, mock_index_vcon, mock_add_vcon_to_set, mock_get_ingress_auth
+    ):
+        """Test that API keys are properly isolated between ingress lists."""
+        # Configure different API keys for different ingress lists
+        mock_get_ingress_auth.return_value = {
+            "partner_a_ingress": "partner-a-key",
+            "partner_b_ingress": ["partner-b-key-1", "partner-b-key-2"],
+            "shared_ingress": ["partner-a-key", "partner-b-key-1", "shared-key"],
+        }
+
+        # Mock Redis client properly
+        mock_redis = MagicMock()
+        mock_json = MagicMock()
+        mock_json.set = AsyncMock()
+        mock_redis.json.return_value = mock_json
+        mock_redis.rpush = AsyncMock()
+
+        # Set the global redis_async directly in the api module
+        api.redis_async = mock_redis
+
+        try:
+            # Test partner A can access their ingress
+            response = self.client.post(
+                "/vcon/external-ingress?ingress_list=partner_a_ingress",
+                json=self.test_vcon,
+                headers={CONSERVER_HEADER_NAME: "partner-a-key"},
+            )
+            assert response.status_code == 204
+
+            # Test partner A cannot access partner B's ingress
+            response = self.client.post(
+                "/vcon/external-ingress?ingress_list=partner_b_ingress",
+                json=self.test_vcon,
+                headers={CONSERVER_HEADER_NAME: "partner-a-key"},
+            )
+            assert response.status_code == 403
+
+            # Test partner B can access shared ingress
+            response = self.client.post(
+                "/vcon/external-ingress?ingress_list=shared_ingress",
+                json=self.test_vcon,
+                headers={CONSERVER_HEADER_NAME: "partner-b-key-1"},
+            )
+            assert response.status_code == 204
+
+        finally:
+            # Clean up the global variable
+            api.redis_async = None
+
+    def test_missing_ingress_list_parameter(self):
+        """Test rejection when ingress_list parameter is missing."""
+        response = self.client.post(
+            "/vcon/external-ingress",  # No ingress_list parameter
+            json=self.test_vcon,
+            headers={CONSERVER_HEADER_NAME: self.valid_api_key},
+        )
+
+        assert response.status_code == 422  # FastAPI validation error
+        assert "field required" in response.text.lower()
+
+    def test_invalid_vcon_data(self):
+        """Test rejection with invalid vCon data."""
+        invalid_vcon = {"invalid": "data"}
+
+        response = self.client.post(
+            f"/vcon/external-ingress?ingress_list={self.ingress_list}",
+            json=invalid_vcon,
+            headers={CONSERVER_HEADER_NAME: self.valid_api_key},
+        )
+
+        assert response.status_code == 422  # FastAPI validation error


### PR DESCRIPTION
- Introduced `ingress_auth` configuration in `example_config.yml` for managing API keys for different ingress lists.
- Updated `README.md` to include details about the new API key authentication and external ingress API endpoint.
- Implemented `external_ingress_vcon` endpoint in `api.py` for secure submission of vCons from external partners with scoped access.
- Added validation for API keys specific to ingress lists.
- Enhanced error handling and logging for API submissions.
- Created unit tests for the new external ingress functionality in `test_external_ingress.py`.