### PR TITLE
Fix worker crash when no ingress lists are configured (CON-510)

### DIFF
--- a/server/config.py
+++ b/server/config.py
@@ -8,7 +8,7 @@ def get_config() -> dict:
     """This is to keep logic of accessing config in one place"""
     global _config
     with open(settings.CONSERVER_CONFIG_FILE) as file:
-        _config = yaml.safe_load(file)
+        _config = yaml.safe_load(file) or {}
     return _config
 
 

--- a/server/main.py
+++ b/server/main.py
@@ -642,7 +642,12 @@ def worker_loop(worker_id: int) -> None:
         ingress_chain_map = get_ingress_chain_map()
         all_ingress_lists = list(ingress_chain_map.keys())
         logger.debug("[%s] Monitoring ingress lists: %s", worker_name, all_ingress_lists)
-        
+
+        if not all_ingress_lists:
+            logger.warning("[%s] No ingress lists configured, retrying in 15s", worker_name)
+            time.sleep(15)
+            continue
+
         logger.debug("[%s] Waiting for vCon on ingress lists (timeout: 15s)", worker_name)
         popped_item = r.blpop(all_ingress_lists, timeout=15)
         if not popped_item:

--- a/server/tests/test_config_null.py
+++ b/server/tests/test_config_null.py
@@ -1,0 +1,94 @@
+"""Tests for get_config() handling of null/empty config files (CON-510)."""
+
+import io
+import pytest
+from unittest.mock import patch, mock_open
+
+
+class TestGetConfigNullHandling:
+    """Test that get_config() returns {} when yaml.safe_load returns None."""
+
+    def test_get_config_returns_empty_dict_when_yaml_is_null(self):
+        """All-comment YAML makes yaml.safe_load return None; get_config must return {}."""
+        import importlib
+        import config
+        importlib.reload(config)
+        from config import get_config
+
+        # yaml.safe_load returns None for a file with only comments
+        null_yaml = "# just a comment\n"
+        with patch("builtins.open", mock_open(read_data=null_yaml)):
+            result = get_config()
+
+        assert result == {}, f"Expected {{}} but got {result!r}"
+
+    def test_get_config_returns_empty_dict_when_file_is_empty(self):
+        """Completely empty file also makes yaml.safe_load return None."""
+        import importlib
+        import config
+        importlib.reload(config)
+        from config import get_config
+
+        with patch("builtins.open", mock_open(read_data="")):
+            result = get_config()
+
+        assert result == {}, f"Expected {{}} but got {result!r}"
+
+    def test_get_config_returns_dict_when_valid(self):
+        """Normal config file should be returned as-is."""
+        import importlib
+        import config
+        importlib.reload(config)
+        from config import get_config
+
+        valid_yaml = "chains:\n  my_chain:\n    ingress_lists:\n      - my_queue\n"
+        with patch("builtins.open", mock_open(read_data=valid_yaml)):
+            result = get_config()
+
+        assert result == {"chains": {"my_chain": {"ingress_lists": ["my_queue"]}}}
+
+
+class TestGetIngressChainMapNullConfig:
+    """Test that get_ingress_chain_map() does not crash when config is null."""
+
+    def test_get_ingress_chain_map_logic_with_null_config(self):
+        """Simulate get_ingress_chain_map() logic when config is {} (null yaml result).
+
+        The real function does:
+            chains = config.get("chains", {})
+            for chain_name, chain_config in chains.items(): ...
+        This must not crash when config is {}.
+        """
+        import importlib
+        import config
+        importlib.reload(config)
+        from config import get_config
+
+        null_yaml = "# only comments\n"
+        with patch("builtins.open", mock_open(read_data=null_yaml)):
+            cfg = get_config()
+
+        # Replicate get_ingress_chain_map logic
+        chains = cfg.get("chains", {})
+        ingress_details = {}
+        for chain_name, chain_config in chains.items():
+            for ingress_list in chain_config.get("ingress_lists", []):
+                ingress_details[ingress_list] = {"name": chain_name, **chain_config}
+
+        assert ingress_details == {}
+
+    def test_worker_loop_does_not_crash_on_null_config(self):
+        """Simulate the worker_loop config reload path with a null config."""
+        import importlib
+        import config
+        importlib.reload(config)
+        from config import get_config
+
+        # Verify that calling .get() on the result of get_config() doesn't raise
+        null_yaml = "# nothing here\n"
+        with patch("builtins.open", mock_open(read_data=null_yaml)):
+            cfg = get_config()
+
+        # This is exactly what get_ingress_chain_map() does — must not raise
+        chains = cfg.get("chains", {})
+        assert chains == {}

--- a/server/tests/test_config_null.py
+++ b/server/tests/test_config_null.py
@@ -1,8 +1,7 @@
 """Tests for get_config() handling of null/empty config files (CON-510)."""
 
-import io
-import pytest
 from unittest.mock import patch, mock_open
+from config import get_config
 
 
 class TestGetConfigNullHandling:
@@ -10,11 +9,6 @@ class TestGetConfigNullHandling:
 
     def test_get_config_returns_empty_dict_when_yaml_is_null(self):
         """All-comment YAML makes yaml.safe_load return None; get_config must return {}."""
-        import importlib
-        import config
-        importlib.reload(config)
-        from config import get_config
-
         # yaml.safe_load returns None for a file with only comments
         null_yaml = "# just a comment\n"
         with patch("builtins.open", mock_open(read_data=null_yaml)):
@@ -24,11 +18,6 @@ class TestGetConfigNullHandling:
 
     def test_get_config_returns_empty_dict_when_file_is_empty(self):
         """Completely empty file also makes yaml.safe_load return None."""
-        import importlib
-        import config
-        importlib.reload(config)
-        from config import get_config
-
         with patch("builtins.open", mock_open(read_data="")):
             result = get_config()
 
@@ -36,11 +25,6 @@ class TestGetConfigNullHandling:
 
     def test_get_config_returns_dict_when_valid(self):
         """Normal config file should be returned as-is."""
-        import importlib
-        import config
-        importlib.reload(config)
-        from config import get_config
-
         valid_yaml = "chains:\n  my_chain:\n    ingress_lists:\n      - my_queue\n"
         with patch("builtins.open", mock_open(read_data=valid_yaml)):
             result = get_config()
@@ -59,11 +43,6 @@ class TestGetIngressChainMapNullConfig:
             for chain_name, chain_config in chains.items(): ...
         This must not crash when config is {}.
         """
-        import importlib
-        import config
-        importlib.reload(config)
-        from config import get_config
-
         null_yaml = "# only comments\n"
         with patch("builtins.open", mock_open(read_data=null_yaml)):
             cfg = get_config()
@@ -79,11 +58,6 @@ class TestGetIngressChainMapNullConfig:
 
     def test_worker_loop_does_not_crash_on_null_config(self):
         """Simulate the worker_loop config reload path with a null config."""
-        import importlib
-        import config
-        importlib.reload(config)
-        from config import get_config
-
         # Verify that calling .get() on the result of get_config() doesn't raise
         null_yaml = "# nothing here\n"
         with patch("builtins.open", mock_open(read_data=null_yaml)):


### PR DESCRIPTION
## Summary

- Guards against calling `blpop` with an empty list, which raises an uncaught `ResponseError` and crashes the worker
- Worker now logs a warning and retries after 15s when no ingress lists are found, staying alive until a valid config is available

## Test plan

- [ ] Deploy with a null/empty config and verify the worker logs a warning every 15s instead of crashing
- [ ] Set a valid config and verify the worker resumes picking up vCons without restart

Fixes CON-510

🤖 Generated with [Claude Code](https://claude.com/claude-code)