### PR TITLE
fix(CON-519): resolve vendor from opts instead of hardcoding openai in analyze link

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ static
 !static/styles.css
 config.json
 config.yml
+litellm_config.yaml
 
 .data
 tmp

--- a/server/lib/openai_client.py
+++ b/server/lib/openai_client.py
@@ -86,6 +86,75 @@ def get_openai_client(opts=None):
     )
 
 
+def get_vendor_from_opts(opts=None):
+    """
+    Determine the AI vendor string from opts.
+
+    When using LiteLLM, tries to infer the actual provider from the model
+    name in opts (e.g. "claude-*" -> "anthropic"). Falls back to "litellm"
+    if the model name doesn't match a known pattern.
+
+    Returns one of: "openai", "azure", "anthropic", "google", "mistral",
+    "meta", "cohere", or "litellm".
+    """
+    opts = opts or {}
+    litellm_url = (opts.get("LITELLM_PROXY_URL") or "").strip()
+    litellm_key = (opts.get("LITELLM_MASTER_KEY") or "").strip()
+    if litellm_url and litellm_key:
+        model = opts.get("model") or ""
+        inferred = _infer_vendor_from_model_name(model)
+        return inferred if inferred else "litellm"
+
+    azure_endpoint = (opts.get("AZURE_OPENAI_ENDPOINT") or "").strip()
+    azure_api_key = (opts.get("AZURE_OPENAI_API_KEY") or "").strip()
+    if azure_endpoint and azure_api_key:
+        return "azure"
+
+    return "openai"
+
+
+def _infer_vendor_from_model_name(model_name):
+    """Infer vendor from a model name string. Returns None if unknown.
+
+    Handles LiteLLM provider-prefixed names (e.g. "azure/gpt-4o",
+    "anthropic/claude-3") as well as bare model names (e.g. "gpt-4o-mini").
+    """
+    if not model_name:
+        return None
+    parts = model_name.lower().split("/")
+    # If a provider prefix is present, use it directly
+    if len(parts) > 1:
+        prefix_map = {
+            "openai": "openai",
+            "azure": "azure",
+            "anthropic": "anthropic",
+            "google": "google",
+            "vertex_ai": "google",
+            "mistral": "mistral",
+            "meta": "meta",
+            "cohere": "cohere",
+            "groq": "groq",
+            "bedrock": "bedrock",
+        }
+        if parts[0] in prefix_map:
+            return prefix_map[parts[0]]
+    # Fall back to model name pattern matching on the last segment
+    m = parts[-1]
+    if m.startswith("claude"):
+        return "anthropic"
+    if m.startswith("gpt-") or m.startswith("o1") or m.startswith("o3") or m.startswith("chatgpt"):
+        return "openai"
+    if m.startswith("gemini"):
+        return "google"
+    if m.startswith("mistral") or m.startswith("mixtral"):
+        return "mistral"
+    if m.startswith("llama") or m.startswith("meta-llama"):
+        return "meta"
+    if m.startswith("command"):
+        return "cohere"
+    return None
+
+
 def get_async_openai_client(opts=None):
     """
     Return an async OpenAI-compatible client. Same opts semantics as get_openai_client.

--- a/server/links/analyze/__init__.py
+++ b/server/links/analyze/__init__.py
@@ -1,6 +1,6 @@
 from lib.vcon_redis import VconRedis
 from lib.logging_utils import init_logger
-from lib.openai_client import get_openai_client
+from lib.openai_client import get_openai_client, get_vendor_from_opts
 import logging
 from tenacity import (
     retry,
@@ -169,7 +169,7 @@ def run(
         vCon.add_analysis(
             type=opts["analysis_type"],
             dialog=index,
-            vendor="openai",
+            vendor=get_vendor_from_opts(opts),
             body=analysis,
             encoding="none",
             extra={


### PR DESCRIPTION
## Summary

- Adds `get_vendor_from_opts(opts)` to `server/lib/openai_client.py` that returns the correct vendor string based on how the LLM client is configured
- Adds `_infer_vendor_from_model_name()` helper that handles LiteLLM provider-prefixed model names (e.g. `azure/gpt-4o` → `"azure"`, `anthropic/claude-3` → `"anthropic"`) and bare model names (e.g. `gpt-4o-mini` → `"openai"`)
- Replaces hardcoded `vendor="openai"` in `server/links/analyze/__init__.py` with `vendor=get_vendor_from_opts(opts)`
- Adds `litellm_config.yaml` to `.gitignore` since it contains API credentials

## Vendor resolution logic

| Configuration | Model example | Vendor set |
|---|---|---|
| Direct OpenAI | `gpt-4o` | `openai` |
| Azure OpenAI | `gpt-4o-mini` | `azure` |
| LiteLLM + OpenAI model | `gpt-4o` | `openai` |
| LiteLLM + Azure-prefixed model | `azure/gpt-4o` | `azure` |
| LiteLLM + Anthropic model | `claude-3-haiku` | `anthropic` |
| LiteLLM + unknown model | `my-custom-model` | `litellm` |

## How to test

1. Copy `example_config.yml` to `config.yml` and configure an analyze link (e.g. `summarize` or `diarize`)
2. Create a `litellm_config.yaml` (see below — it is gitignored) and start the stack with `docker compose up`

**Scenario A — Direct OpenAI** (`vendor` should be `"openai"`):
```yaml
# config.yml analyze link options
OPENAI_API_KEY: <your-key>
model: gpt-4o-mini
```

**Scenario B — Azure OpenAI** (`vendor` should be `"azure"`):
```yaml
AZURE_OPENAI_API_KEY: <key>
AZURE_OPENAI_ENDPOINT: https://<resource>.openai.azure.com/
AZURE_OPENAI_API_VERSION: 2025-01-01-preview
model: gpt-4o-mini
```

**Scenario C — LiteLLM → OpenAI** (`vendor` should be `"openai"`):
```yaml
LITELLM_PROXY_URL: http://litellm:4000
LITELLM_MASTER_KEY: sk-portal-litellm-master
model: gpt-4o-mini
```

**Scenario D — LiteLLM → Azure** (`vendor` should be `"azure"`):
```yaml
LITELLM_PROXY_URL: http://litellm:4000
LITELLM_MASTER_KEY: sk-portal-litellm-master
model: azure/gpt-4o-mini
```

After processing a vCon, check the `analysis` array — the `vendor` field should reflect the scenario above.

## Linear

Fixes [CON-519](https://linear.app/vconic/issue/CON-519)

🤖 Generated with [Claude Code](https://claude.com/claude-code)