### PR TITLE
Port main branch updates to refactored api/common/conserver structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ tmp
 
 traefik/
 redis_data/
+litellm_config.yaml

--- a/api/api.py
+++ b/api/api.py
@@ -954,7 +954,7 @@ async def get_vcon_count(
 async def get_config() -> JSONResponse:
     """Get the current system configuration.
 
-    Reads and returns the configuration from the file specified in CONSERVER_CONFIG_FILE.
+    Returns the current configuration via Configuration.get_config().
 
     Returns:
         JSONResponse containing the configuration
@@ -963,8 +963,7 @@ async def get_config() -> JSONResponse:
         HTTPException: If there is an error reading the config file
     """
     try:
-        with open(os.getenv("CONSERVER_CONFIG_FILE"), "r") as f:
-            config = yaml.safe_load(f)
+        config = Configuration.get_config()
         return JSONResponse(content=config)
     except Exception as e:
         logger.error(f"Error reading config: {str(e)}")

--- a/common/lib/openai_client.py
+++ b/common/lib/openai_client.py
@@ -1,0 +1,132 @@
+"""
+Shared OpenAI/Azure/LiteLLM client for vcon-server.
+
+When LITELLM_PROXY_URL and LITELLM_MASTER_KEY are set in opts,
+returns an OpenAI client configured to use the LiteLLM proxy. Otherwise uses
+direct OpenAI or Azure OpenAI credentials from opts.
+
+All links and storage that call OpenAI should use get_openai_client(opts) so
+LLM provider and proxy can be switched in one place.
+"""
+from openai import OpenAI, AzureOpenAI, AsyncOpenAI, AsyncAzureOpenAI
+
+from lib.logging_utils import init_logger
+
+logger = init_logger(__name__)
+
+# Default Azure API version when not specified
+DEFAULT_AZURE_OPENAI_API_VERSION = "2024-10-21"
+
+
+def get_openai_client(opts=None):
+    """
+    Return an OpenAI-compatible client (OpenAI or AzureOpenAI).
+    Same client is used for chat and embeddings; LiteLLM proxy supports both.
+
+    opts: dict of options. All values are read from opts only.
+
+    Supported keys in opts:
+      - LITELLM_PROXY_URL, LITELLM_MASTER_KEY  -> use LiteLLM proxy (chat + embeddings)
+      - AZURE_OPENAI_ENDPOINT, AZURE_OPENAI_API_KEY, AZURE_OPENAI_API_VERSION -> Azure
+      - OPENAI_API_KEY or openai_api_key or api_key -> OpenAI
+      - organization / organization_key, project / project_key (optional)
+    """
+    opts = opts or {}
+
+    litellm_url = (opts.get("LITELLM_PROXY_URL") or "").strip().rstrip("/")
+    litellm_key = (opts.get("LITELLM_MASTER_KEY") or "").strip()
+
+    if litellm_url and litellm_key:
+        logger.info("Using LiteLLM proxy at %s", litellm_url)
+        organization = opts.get("organization") or opts.get("organization_key")
+        project = opts.get("project") or opts.get("project_key")
+        return OpenAI(
+            api_key=litellm_key,
+            base_url=litellm_url,
+            organization=organization if organization else None,
+            project=project if project else None,
+            timeout=120.0,
+            max_retries=0,
+        )
+
+    azure_endpoint = (opts.get("AZURE_OPENAI_ENDPOINT") or "").strip()
+    azure_api_key = (opts.get("AZURE_OPENAI_API_KEY") or "").strip()
+    azure_api_version = opts.get("AZURE_OPENAI_API_VERSION") or DEFAULT_AZURE_OPENAI_API_VERSION
+
+    if azure_endpoint and azure_api_key:
+        logger.info("Using Azure OpenAI client at endpoint: %s", azure_endpoint)
+        return AzureOpenAI(
+            api_key=azure_api_key,
+            azure_endpoint=azure_endpoint,
+            api_version=azure_api_version,
+            timeout=120.0,
+            max_retries=0,
+        )
+
+    openai_api_key = (
+        opts.get("OPENAI_API_KEY")
+        or opts.get("openai_api_key")
+        or opts.get("api_key")
+    )
+    if openai_api_key:
+        logger.info("Using public OpenAI client")
+        organization = opts.get("organization") or opts.get("organization_key")
+        project = opts.get("project") or opts.get("project_key")
+        return OpenAI(
+            api_key=openai_api_key,
+            organization=organization if organization else None,
+            project=project if project else None,
+            timeout=120.0,
+            max_retries=0,
+        )
+
+    raise ValueError(
+        "Set LITELLM_PROXY_URL + LITELLM_MASTER_KEY, or "
+        "AZURE_OPENAI_ENDPOINT + AZURE_OPENAI_API_KEY, or OPENAI_API_KEY (or api_key)"
+    )
+
+
+def get_async_openai_client(opts=None):
+    """
+    Return an async OpenAI-compatible client. Same opts semantics as get_openai_client.
+    LiteLLM proxy is used for both chat and embeddings when configured.
+    """
+    opts = opts or {}
+
+    litellm_url = (opts.get("LITELLM_PROXY_URL") or "").strip().rstrip("/")
+    litellm_key = (opts.get("LITELLM_MASTER_KEY") or "").strip()
+    if litellm_url and litellm_key:
+        logger.info("Using LiteLLM proxy at %s (async)", litellm_url)
+        return AsyncOpenAI(
+            api_key=litellm_key,
+            base_url=litellm_url + "/v1",
+            timeout=120.0,
+            max_retries=0,
+        )
+
+    azure_endpoint = (opts.get("AZURE_OPENAI_ENDPOINT") or "").strip()
+    azure_api_key = (opts.get("AZURE_OPENAI_API_KEY") or "").strip()
+    azure_api_version = opts.get("AZURE_OPENAI_API_VERSION") or DEFAULT_AZURE_OPENAI_API_VERSION
+    if azure_endpoint and azure_api_key:
+        logger.info("Using Azure OpenAI client at endpoint: %s (async)", azure_endpoint)
+        return AsyncAzureOpenAI(
+            api_key=azure_api_key,
+            azure_endpoint=azure_endpoint,
+            api_version=azure_api_version,
+            timeout=120.0,
+            max_retries=0,
+        )
+
+    openai_api_key = (
+        opts.get("OPENAI_API_KEY")
+        or opts.get("openai_api_key")
+        or opts.get("api_key")
+    )
+    if openai_api_key:
+        logger.info("Using public OpenAI client (async)")
+        return AsyncOpenAI(api_key=openai_api_key, timeout=120.0, max_retries=0)
+
+    raise ValueError(
+        "Set LITELLM_PROXY_URL + LITELLM_MASTER_KEY, or "
+        "AZURE_OPENAI_ENDPOINT + AZURE_OPENAI_API_KEY, or OPENAI_API_KEY (or api_key)"
+    )

--- a/common/storage/chatgpt_files/__init__.py
+++ b/common/storage/chatgpt_files/__init__.py
@@ -1,8 +1,8 @@
 from lib.logging_utils import init_logger
+from lib.openai_client import get_openai_client
 import json
 import os
 import redis_mgr
-from openai import OpenAI
 
 logger = init_logger(__name__)
 
@@ -29,12 +29,9 @@ def save(vcon_uuid: str, options: dict = default_options) -> None:
         file_name = f"{vcon_uuid}.vcon.json"
         with open(file_name, "w") as file:
             json.dump(vcon, file)
-        client = OpenAI(
-            organization=options["organization_key"],
-            project=options["project_key"],
-            api_key=options["api_key"],
-        )
-        file = client.files.create(file=open(file_name, "rb"), purpose=options["purpose"])
+        client = get_openai_client(options)
+        with open(file_name, "rb") as upload_file:
+            file = client.files.create(file=upload_file, purpose=options["purpose"])
         os.remove(file_name)
         client.beta.vector_stores.files.create(vector_store_id=options["vector_store_id"], file_id=file.id)
     except Exception as error:

--- a/common/storage/milvus/__init__.py
+++ b/common/storage/milvus/__init__.py
@@ -14,7 +14,7 @@ from lib.vcon_redis import VconRedis
 
 try:
     from pymilvus import connections, Collection, FieldSchema, CollectionSchema, DataType, utility
-    from openai import OpenAI
+    from lib.openai_client import get_openai_client
 except ImportError:
     logging.error("Required packages not found. Install with: pip install pymilvus openai")
     raise
@@ -446,12 +446,9 @@ def save(vcon_uuid: str, opts=default_options) -> None:
                 logger.info(f"vCon {vcon_uuid} already exists in Milvus collection {collection_name}, skipping")
                 return
         
-        # Initialize OpenAI client
-        openai_client = OpenAI(
-            api_key=opts["api_key"],
-            organization=opts["organization"] if opts["organization"] else None
-        )
-        
+        # Initialize OpenAI client (supports LiteLLM proxy via LITELLM_PROXY_URL + LITELLM_MASTER_KEY provided in opts)
+        openai_client = get_openai_client(opts)
+
         # Extract text content from vCon
         text = extract_text_from_vcon(vcon_dict)
         

--- a/common/tests/test_external_ingress.py
+++ b/common/tests/test_external_ingress.py
@@ -39,9 +39,9 @@ class TestExternalIngress:
 
     @patch("config.Configuration.get_ingress_auth")
     @patch("api.add_vcon_to_set")
-    @patch("api.index_vcon_parties")
+    @patch("api.index_vcon")
     def test_successful_submission_single_api_key(
-        self, mock_index_vcon_parties, mock_add_vcon_to_set, mock_get_ingress_auth
+        self, mock_index_vcon, mock_add_vcon_to_set, mock_get_ingress_auth
     ):
         """Test successful vCon submission with single API key configuration."""
         # Configure mocks
@@ -89,9 +89,9 @@ class TestExternalIngress:
 
     @patch("config.Configuration.get_ingress_auth")
     @patch("api.add_vcon_to_set")
-    @patch("api.index_vcon_parties")
+    @patch("api.index_vcon")
     def test_successful_submission_multiple_api_keys(
-        self, mock_index_vcon_parties, mock_add_vcon_to_set, mock_get_ingress_auth
+        self, mock_index_vcon, mock_add_vcon_to_set, mock_get_ingress_auth
     ):
         """Test successful vCon submission with multiple API keys for same ingress."""
         # Configure mocks - multiple API keys for same ingress list

--- a/common/tests/test_post_vcon_expiry.py
+++ b/common/tests/test_post_vcon_expiry.py
@@ -69,6 +69,7 @@ class TestPostVconExpiry:
 
     def test_post_vcon_expiry_value_is_3600(self):
         """Test that the default expiry value is 3600 seconds (1 hour)."""
+        # Verify the configured value
         assert VCON_REDIS_EXPIRY == 3600, "Default VCON_REDIS_EXPIRY should be 3600 seconds"
 
     @patch("api.add_vcon_to_set")

--- a/conserver/links/analyze/__init__.py
+++ b/conserver/links/analyze/__init__.py
@@ -1,7 +1,7 @@
 from lib.vcon_redis import VconRedis
 from lib.logging_utils import init_logger
+from lib.openai_client import get_openai_client
 import logging
-from openai import OpenAI, AzureOpenAI
 from tenacity import (
     retry,
     stop_after_attempt,
@@ -98,24 +98,7 @@ def run(
         logger.info(f"Skipping {link_name} vCon {vcon_uuid} due to sampling")
         return vcon_uuid
 
-    # Extract credentials from options
-    openai_api_key = opts.get("OPENAI_API_KEY")
-    azure_openai_api_key = opts.get("AZURE_OPENAI_API_KEY")
-    azure_openai_endpoint = opts.get("AZURE_OPENAI_ENDPOINT")
-    api_version = opts.get("AZURE_OPENAI_API_VERSION")
-
-    client = None
-    if openai_api_key:
-        client = OpenAI(api_key=openai_api_key, timeout=120.0, max_retries=0)
-        logger.info("Using public OpenAI client")
-    elif azure_openai_api_key and azure_openai_endpoint:
-        client = AzureOpenAI(api_key=azure_openai_api_key, azure_endpoint=azure_openai_endpoint, api_version=api_version)
-        logger.info(f"Using Azure OpenAI client at endpoint:{azure_openai_endpoint}")
-    else:
-        raise ValueError(
-            "OpenAI or Azure OpenAI credentials not provided. "
-            "Need OPENAI_API_KEY or AZURE_OPENAI_API_KEY and AZURE_OPENAI_ENDPOINT"
-        )
+    client = get_openai_client(opts)
 
     source_type = navigate_dict(opts, "source.analysis_type")
     text_location = navigate_dict(opts, "source.text_location")

--- a/conserver/links/analyze_and_label/__init__.py
+++ b/conserver/links/analyze_and_label/__init__.py
@@ -1,8 +1,8 @@
 from lib.vcon_redis import VconRedis
 from lib.logging_utils import init_logger
+from lib.openai_client import get_openai_client
 import logging
 import json
-from openai import OpenAI
 from tenacity import (
     retry,
     stop_after_attempt,
@@ -79,7 +79,7 @@ def run(
         logger.info(f"Skipping {link_name} vCon {vcon_uuid} due to sampling")
         return vcon_uuid
 
-    client = OpenAI(api_key=opts["OPENAI_API_KEY"], timeout=120.0, max_retries=0)
+    client = get_openai_client(opts)
     source_type = navigate_dict(opts, "source.analysis_type")
     text_location = navigate_dict(opts, "source.text_location")
 

--- a/conserver/links/analyze_and_label/tests/test_analyze_and_label.py
+++ b/conserver/links/analyze_and_label/tests/test_analyze_and_label.py
@@ -1,7 +1,7 @@
 import os
 import json
 import pytest
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch, MagicMock, Mock
 
 from server.links.analyze_and_label import run, generate_analysis_with_labels, get_analysis_for_type, navigate_dict
 from server.vcon import Vcon
@@ -222,11 +222,13 @@ def test_navigate_dict():
     assert navigate_dict(test_dict, "z") is None
 
 
+@patch('server.links.analyze_and_label.get_openai_client')
 @patch('server.links.analyze_and_label.generate_analysis_with_labels')
 @patch('server.links.analyze_and_label.is_included', return_value=True)
 @patch('server.links.analyze_and_label.randomly_execute_with_sampling', return_value=True)
-def test_run_basic(mock_sampling, mock_is_included, mock_generate_analysis, mock_redis_with_vcon, sample_vcon):
+def test_run_basic(mock_sampling, mock_is_included, mock_generate_analysis, mock_get_client, mock_redis_with_vcon, sample_vcon):
     """Test the basic run functionality with mocked analysis generation"""
+    mock_get_client.return_value = Mock()
     # Set up mock to return analysis JSON
     mock_generate_analysis.return_value = json.dumps({
         "labels": ["customer_service", "billing_issue", "refund"]
@@ -264,12 +266,14 @@ def test_run_basic(mock_sampling, mock_is_included, mock_generate_analysis, mock
     assert "refund:refund" in tags_attachment["body"]
 
 
+@patch('server.links.analyze_and_label.get_openai_client')
 @patch('server.links.analyze_and_label.get_analysis_for_type')
 @patch('server.links.analyze_and_label.generate_analysis_with_labels')
 @patch('server.links.analyze_and_label.is_included', return_value=True)
 @patch('server.links.analyze_and_label.randomly_execute_with_sampling', return_value=True)
-def test_run_skip_existing_analysis(mock_sampling, mock_is_included, mock_generate_analysis, mock_get_analysis, mock_redis_with_vcon, sample_vcon_with_analysis):
+def test_run_skip_existing_analysis(mock_sampling, mock_is_included, mock_generate_analysis, mock_get_analysis, mock_get_client, mock_redis_with_vcon, sample_vcon_with_analysis):
     """Test that run skips dialogs with existing labeled analysis"""
+    mock_get_client.return_value = Mock()
     # Set up mock for generate_analysis_with_labels
     mock_generate_analysis.return_value = json.dumps({
         "labels": ["new_label_that_should_not_be_added"]
@@ -307,11 +311,13 @@ def test_run_skip_existing_analysis(mock_sampling, mock_is_included, mock_genera
     mock_generate_analysis.assert_not_called()
 
 
+@patch('server.links.analyze_and_label.get_openai_client')
 @patch('server.links.analyze_and_label.generate_analysis_with_labels')
 @patch('server.links.analyze_and_label.is_included', return_value=True)
 @patch('server.links.analyze_and_label.randomly_execute_with_sampling', return_value=True)
-def test_run_json_parse_error(mock_sampling, mock_is_included, mock_generate_analysis, mock_redis_with_vcon, sample_vcon):
+def test_run_json_parse_error(mock_sampling, mock_is_included, mock_generate_analysis, mock_get_client, mock_redis_with_vcon, sample_vcon):
     """Test handling of JSON parse errors"""
+    mock_get_client.return_value = Mock()
     # Set up mock to return invalid JSON
     mock_generate_analysis.return_value = "This is not valid JSON"
     
@@ -338,11 +344,13 @@ def test_run_json_parse_error(mock_sampling, mock_is_included, mock_generate_ana
     assert tags_attachment is None or len(tags_attachment["body"]) == 0
 
 
+@patch('server.links.analyze_and_label.get_openai_client')
 @patch('server.links.analyze_and_label.generate_analysis_with_labels')
 @patch('server.links.analyze_and_label.is_included', return_value=True)
 @patch('server.links.analyze_and_label.randomly_execute_with_sampling', return_value=True)
-def test_run_analysis_exception(mock_sampling, mock_is_included, mock_generate_analysis, mock_redis_with_vcon, sample_vcon):
+def test_run_analysis_exception(mock_sampling, mock_is_included, mock_generate_analysis, mock_get_client, mock_redis_with_vcon, sample_vcon):
     """Test handling of analysis generation exceptions"""
+    mock_get_client.return_value = Mock()
     # Make analysis function raise an exception
     mock_generate_analysis.side_effect = Exception("Analysis generation failed")
     
@@ -358,11 +366,13 @@ def test_run_analysis_exception(mock_sampling, mock_is_included, mock_generate_a
         run("test-uuid", "analyze_and_label", opts)
 
 
+@patch('server.links.analyze_and_label.get_openai_client')
 @patch('server.links.analyze_and_label.generate_analysis_with_labels')
 @patch('server.links.analyze_and_label.is_included', return_value=True)
 @patch('server.links.analyze_and_label.randomly_execute_with_sampling', return_value=True)
-def test_run_message_format(mock_sampling, mock_is_included, mock_generate_analysis, mock_redis_with_vcon, sample_vcon_message_format):
+def test_run_message_format(mock_sampling, mock_is_included, mock_generate_analysis, mock_get_client, mock_redis_with_vcon, sample_vcon_message_format):
     """Test analyzing a dialog with message format"""
+    mock_get_client.return_value = Mock()
     # Set up the mock Redis instance to return our sample vCon with message format
     mock_instance = mock_redis_with_vcon.return_value
     mock_instance.get_vcon.return_value = sample_vcon_message_format

--- a/conserver/links/analyze_vcon/__init__.py
+++ b/conserver/links/analyze_vcon/__init__.py
@@ -1,7 +1,7 @@
 from lib.vcon_redis import VconRedis
 from lib.logging_utils import init_logger
+from lib.openai_client import get_openai_client
 import logging
-from openai import OpenAI
 from tenacity import (
     retry,
     stop_after_attempt,
@@ -119,8 +119,8 @@ def run(
         )
         return vcon_uuid
 
-    client = OpenAI(api_key=opts["OPENAI_API_KEY"], timeout=120.0, max_retries=0)
-    
+    client = get_openai_client(opts)
+
     # Prepare vCon data for analysis (removing body properties if specified)
     vcon_data = prepare_vcon_for_analysis(vCon, opts["remove_body_properties"])
     

--- a/conserver/links/check_and_tag/__init__.py
+++ b/conserver/links/check_and_tag/__init__.py
@@ -1,8 +1,8 @@
 from lib.vcon_redis import VconRedis
 from lib.logging_utils import init_logger
+from lib.openai_client import get_openai_client
 import logging
 import json
-from openai import OpenAI
 from tenacity import (
     retry,
     stop_after_attempt,
@@ -101,7 +101,7 @@ def run(
         logger.info(f"Skipping {link_name} vCon {vcon_uuid} due to sampling")
         return vcon_uuid
 
-    client = OpenAI(api_key=opts["OPENAI_API_KEY"], timeout=120.0, max_retries=0)
+    client = get_openai_client(opts)
     source_type = navigate_dict(opts, "source.analysis_type")
     text_location = navigate_dict(opts, "source.text_location")
 

--- a/conserver/links/deepgram_link/__init__.py
+++ b/conserver/links/deepgram_link/__init__.py
@@ -1,5 +1,8 @@
 from typing import Optional
+import os
+import tempfile
 from lib.logging_utils import init_logger
+from lib.openai_client import get_openai_client
 import logging
 from deepgram import DeepgramClient, PrerecordedOptions
 from tenacity import (
@@ -25,10 +28,62 @@ logger = init_logger(__name__)
 
 # Default options for Deepgram transcription link
 # - minimum_duration: minimum length (in seconds) for a dialog to be considered for transcription
-# - DEEPGRAM_KEY: API key for Deepgram
-# - api: dictionary of Deepgram API options
-# (Note: 'api' is not present in the original default_options, but is expected in opts in run)
+# - DEEPGRAM_KEY: API key for Deepgram (when not using LiteLLM proxy)
+# - api: dictionary of Deepgram API options (when using direct Deepgram)
+# - LITELLM_PROXY_URL, LITELLM_MASTER_KEY: when set, transcription goes through LiteLLM proxy (model name in opts["model"], e.g. "nova-3")
 default_options = {"minimum_duration": 60, "DEEPGRAM_KEY": None, "minimum_confidence": 0.5}
+
+
+@retry(
+    wait=wait_exponential(multiplier=2, min=1, max=65),
+    stop=stop_after_attempt(6),
+    before_sleep=before_sleep_log(logger, logging.INFO),
+)
+def transcribe_via_litellm(url: str, opts: dict) -> Optional[dict]:
+    """
+    Transcribe audio at url via LiteLLM proxy (OpenAI-compatible /audio/transcriptions).
+    Returns a dict compatible with the rest of the link: transcript, confidence, detected_language.
+    """
+    litellm_url = (opts.get("LITELLM_PROXY_URL") or "").strip().rstrip("/")
+    litellm_key = (opts.get("LITELLM_MASTER_KEY") or "").strip()
+    if not litellm_url or not litellm_key:
+        return None
+    model = opts.get("model") or (opts.get("api") or {}).get("model", "nova-3")
+    # Download audio (stream to temp file to avoid loading large files into memory)
+    audio_response = requests.get(url, stream=True, timeout=60)
+    audio_response.raise_for_status()
+    ext = os.path.splitext(url.split("?")[0])[-1] or ".mp3"
+    with tempfile.NamedTemporaryFile(delete=False, suffix=ext) as tmp:
+        bytes_written = 0
+        for chunk in audio_response.iter_content(chunk_size=8192):
+            if chunk:
+                tmp.write(chunk)
+                bytes_written += len(chunk)
+        tmp_path = tmp.name
+    if bytes_written == 0:
+        logger.warning("Empty audio content from %s", url)
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        return None
+    try:
+        client = get_openai_client(opts)
+        with open(tmp_path, "rb") as f:
+            response = client.audio.transcriptions.create(model=model, file=f)
+        text = getattr(response, "text", None) or (response.model_dump().get("text") if hasattr(response, "model_dump") else str(response))
+        if text is None:
+            return None
+        # confidence and detected_language are not available in the OpenAI-format response;
+        # omit them so callers can skip confidence filtering instead of applying a fake threshold.
+        return {
+            "transcript": text,
+        }
+    finally:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
 
 
 def get_transcription(vcon, index):
@@ -180,12 +235,17 @@ def run(
             logger.info("Dialog %s already transcribed on vCon: %s", index, vCon.uuid)
             continue
 
-        # Initialize Deepgram client for each dialog (in case key changes)
-        dg_client = DeepgramClient(opts["DEEPGRAM_KEY"])
         start = time.time()
         try:
-            logger.info(f"Transcribing dialog {index} in vCon {vCon.uuid} via Deepgram API...")
-            result = transcribe_dg(dg_client, dialog, opts["api"], vcon_uuid=vcon_uuid, run_opts=opts)
+            if opts.get("LITELLM_PROXY_URL") and opts.get("LITELLM_MASTER_KEY"):
+                logger.info(f"Transcribing dialog {index} in vCon {vCon.uuid} via LiteLLM proxy (Deepgram)...")
+                result = transcribe_via_litellm(dialog["url"], opts)
+            else:
+                if not opts.get("DEEPGRAM_KEY"):
+                    raise ValueError("DEEPGRAM_KEY or (LITELLM_PROXY_URL + LITELLM_MASTER_KEY) required for deepgram link")
+                dg_client = DeepgramClient(opts["DEEPGRAM_KEY"])
+                logger.info(f"Transcribing dialog {index} in vCon {vCon.uuid} via Deepgram API...")
+                result = transcribe_dg(dg_client, dialog, opts["api"], vcon_uuid=vcon_uuid, run_opts=opts)
         except Exception as e:
             logger.error("Failed to transcribe vCon %s after multiple retries: %s", vcon_uuid, e, exc_info=True)
             increment_counter("conserver.link.deepgram.transcription_failures")
@@ -199,21 +259,30 @@ def run(
             increment_counter("conserver.link.deepgram.transcription_failures")
             break
 
-        # Log and track confidence
-        record_histogram("conserver.link.deepgram.confidence", result["confidence"])
-        logger.info(f"Transcription confidence for dialog {index}: {result['confidence']}")
-
-        # If the confidence is too low, don't store the transcript
-        if result["confidence"] < opts["minimum_confidence"]:
-            logger.warning("Low confidence result for vCon %s, dialog %s: %s", vcon_uuid, index, result["confidence"])
-            increment_counter("conserver.link.deepgram.transcription_failures")
-            break
+        # Log and track confidence (not available for LiteLLM/OpenAI-format transcription)
+        confidence = result.get("confidence")
+        if confidence is not None:
+            record_histogram("conserver.link.deepgram.confidence", confidence)
+            logger.info(f"Transcription confidence for dialog {index}: {confidence}")
+            # If the confidence is too low, don't store the transcript
+            if confidence < opts["minimum_confidence"]:
+                logger.warning("Low confidence result for vCon %s, dialog %s: %s", vcon_uuid, index, confidence)
+                increment_counter("conserver.link.deepgram.transcription_failures")
+                continue
+        else:
+            logger.info(f"Confidence not available for dialog {index} (LiteLLM path), skipping threshold check")
 
         logger.info("Transcribed vCon: %s, dialog: %s", vCon.uuid, index)
 
         # Prepare vendor schema, omitting credentials
         vendor_schema = {}
-        sensitive_keys = {"DEEPGRAM_KEY", "ai_usage_api_token", "send_ai_usage_data_to_url"}
+        sensitive_keys = {
+            "DEEPGRAM_KEY",
+            "ai_usage_api_token",
+            "send_ai_usage_data_to_url",
+            "LITELLM_PROXY_URL",
+            "LITELLM_MASTER_KEY",
+        }
         vendor_schema["opts"] = {k: v for k, v in opts.items() if k not in sensitive_keys}
 
         # Add the transcript analysis to the vCon

--- a/conserver/links/detect_engagement/__init__.py
+++ b/conserver/links/detect_engagement/__init__.py
@@ -1,7 +1,7 @@
 from lib.vcon_redis import VconRedis
 from lib.logging_utils import init_logger
+from lib.openai_client import get_openai_client
 import logging
-from openai import OpenAI
 from tenacity import (
     retry,
     stop_after_attempt,
@@ -63,13 +63,6 @@ def run(
     merged_opts.update(opts)
     opts = merged_opts
 
-    # Check for OPENAI_API_KEY in opts or environment
-    openai_key = opts.get("OPENAI_API_KEY") or os.getenv("OPENAI_API_KEY")
-    if not openai_key:
-        logger.warning("OPENAI_API_KEY not defined, skipping analysis for vCon: %s", vcon_uuid)
-        return vcon_uuid
-    opts["OPENAI_API_KEY"] = openai_key
-
     vcon_redis = VconRedis()
     vCon = vcon_redis.get_vcon(vcon_uuid)
 
@@ -81,7 +74,11 @@ def run(
         logger.info(f"Skipping {link_name} vCon {vcon_uuid} due to sampling")
         return vcon_uuid
 
-    client = OpenAI(api_key=opts["OPENAI_API_KEY"], timeout=120.0, max_retries=0)
+    try:
+        client = get_openai_client(opts)
+    except ValueError as e:
+        logger.warning("No LLM credentials (OPENAI_API_KEY, LiteLLM, or Azure): %s; skipping analysis for vCon: %s", e, vcon_uuid)
+        return vcon_uuid
     source_type = opts["source"]["analysis_type"]
     text_location = opts["source"]["text_location"]
 

--- a/conserver/links/detect_engagement/tests/test_detect_engagement.py
+++ b/conserver/links/detect_engagement/tests/test_detect_engagement.py
@@ -146,11 +146,13 @@ async def test_check_engagement_not_engaged():
     )
     assert result is False
 
-def test_run_skips_if_no_transcript(mock_redis, mock_vcon):
+@patch("server.links.detect_engagement.get_openai_client")
+def test_run_skips_if_no_transcript(mock_get_client, mock_redis, mock_vcon):
     """
     Test that run does nothing if there is no transcript analysis present.
     Should not add analysis or tag.
     """
+    mock_get_client.return_value = Mock()
     mock_redis.get_vcon.return_value = mock_vcon
     mock_vcon.analysis = []
     result = run("test-uuid", "test-link", {"OPENAI_API_KEY": os.getenv("OPENAI_API_KEY", "test-key")})
@@ -158,11 +160,15 @@ def test_run_skips_if_no_transcript(mock_redis, mock_vcon):
     mock_vcon.add_analysis.assert_not_called()
     mock_vcon.add_tag.assert_not_called()
 
-def test_run_processes_transcript(mock_redis, mock_vcon):
+@patch("server.links.detect_engagement.get_openai_client")
+def test_run_processes_transcript(mock_get_client, mock_redis, mock_vcon):
     """
     Test that run processes a valid transcript and adds analysis and tag if engagement is detected.
     """
     skip_if_no_openai_key()
+    mock_client = Mock()
+    mock_client.responses.create.return_value = Mock(output_text="true")
+    mock_get_client.return_value = mock_client
     transcript_analysis = {
         "dialog": 0,
         "type": "transcript",

--- a/conserver/links/openai_transcribe/__init__.py
+++ b/conserver/links/openai_transcribe/__init__.py
@@ -18,7 +18,7 @@ import requests
 import tempfile
 import os
 import ffmpeg
-from openai import OpenAI, AzureOpenAI
+from lib.openai_client import get_openai_client
 from pydub import AudioSegment
 from pydub.silence import detect_nonsilent
 
@@ -364,30 +364,9 @@ def transcribe_openai(url: str, opts: dict = None, vcon_uuid: str = None) -> dic
     if opts is None:
         opts = default_options
 
-    # Extract credentials from options
-    openai_api_key = opts.get("OPENAI_API_KEY")
-    azure_openai_api_key = opts.get("AZURE_OPENAI_API_KEY")
-    azure_openai_endpoint = opts.get("AZURE_OPENAI_ENDPOINT")
-    api_version = opts.get("AZURE_OPENAI_API_VERSION")
     model = opts.get("model", "gpt-4o-transcribe")
     max_chunk_duration = opts.get("max_chunk_duration", 480)
-
-    client = None
-    if openai_api_key:
-        client = OpenAI(api_key=openai_api_key)
-        logger.info("Using public OpenAI client")
-    elif azure_openai_api_key and azure_openai_endpoint:
-        client = AzureOpenAI(
-            api_key=azure_openai_api_key,
-            azure_endpoint=azure_openai_endpoint,
-            api_version=api_version
-        )
-        logger.info(f"Using Azure OpenAI client at endpoint:{azure_openai_endpoint}")
-    else:
-        raise ValueError(
-            "OpenAI or Azure OpenAI credentials not provided. "
-            "Need OPENAI_API_KEY or AZURE_OPENAI_API_KEY and AZURE_OPENAI_ENDPOINT"
-        )
+    client = get_openai_client(opts)
 
     try:
         # Download the audio file from the URL

--- a/conserver/links/wtf_transcribe/__init__.py
+++ b/conserver/links/wtf_transcribe/__init__.py
@@ -4,22 +4,23 @@ This link sends vCon audio dialogs to a vfun transcription server and adds
 the results as WTF (World Transcription Format) analysis entries.
 
 The vfun server provides:
-- Multi-language speech recognition (English + auto-detect)
-- Speaker diarization (who spoke when)
+- Multi-language speech recognition (English + Spanish, auto-detect)
 - GPU-accelerated processing with CUDA
 
 Configuration options:
     vfun-server-url: URL of the vfun transcription server (required)
-    diarize: Enable speaker diarization (default: true)
+    language: Language override ("en" or "es"). If omitted, vfun auto-detects.
+    diarize: Enable speaker diarization (default: False)
     timeout: Request timeout in seconds (default: 300)
-    min-duration: Minimum dialog duration to transcribe in seconds (default: 5)
+    min-duration: Minimum dialog duration to transcribe in seconds (default: 0)
     api-key: Optional API key for vfun server authentication
 
 Example configuration in config.yml:
     wtf_transcribe:
       module: links.wtf_transcribe
       options:
-        vfun-server-url: http://localhost:8443/transcribe
+        vfun-server-url: http://localhost:4380/wtf
+        language: en
         diarize: true
         timeout: 300
         min-duration: 5
@@ -29,11 +30,8 @@ Example configuration in config.yml:
 import base64
 import json
 import logging
-import os
-import tempfile
 import requests
-from datetime import datetime, timezone
-from typing import Optional, Dict, Any, List
+from typing import Optional, Dict, Any
 
 from lib.vcon_redis import VconRedis
 from lib.logging_utils import init_logger
@@ -44,9 +42,10 @@ logger = init_logger(__name__)
 
 default_options = {
     "vfun-server-url": None,
-    "diarize": True,
+    "language": None,
+    "diarize": False,
     "timeout": 300,
-    "min-duration": 5,
+    "min-duration": 0,
     "api-key": None,
 }
 
@@ -107,113 +106,23 @@ def get_audio_content(dialog: Dict[str, Any]) -> Optional[bytes]:
 def create_wtf_analysis(
     dialog_index: int,
     vfun_response: Dict[str, Any],
-    duration: float,
+    language: Optional[str] = None,
 ) -> Dict[str, Any]:
-    """Create a WTF analysis entry from vfun response."""
-    now = datetime.now(timezone.utc).isoformat()
+    """Create a WTF analysis entry from vfun response.
 
-    # Extract text and segments from vfun response
-    # vfun returns: analysis[].body with transcription data
-    analysis_entries = vfun_response.get("analysis", [])
-
-    full_text = ""
-    segments = []
-    language = "en-US"
-
-    for entry in analysis_entries:
-        if entry.get("type") in ("transcription", "wtf_transcription"):
-            body = entry.get("body", {})
-
-            # Handle different response formats
-            if isinstance(body, dict):
-                # WTF format from vfun
-                transcript = body.get("transcript", {})
-                full_text = transcript.get("text", body.get("text", ""))
-                language = transcript.get("language", body.get("language", "en-US"))
-                segments = body.get("segments", [])
-            elif isinstance(body, str):
-                full_text = body
-            break
-
-    # If no analysis found, check for direct text field
-    if not full_text:
-        full_text = vfun_response.get("text", "")
-        segments = vfun_response.get("segments", [])
-
-    # Calculate confidence
-    if segments:
-        confidences = [s.get("confidence", 0.9) for s in segments]
-        avg_confidence = sum(confidences) / len(confidences)
-    else:
-        avg_confidence = 0.9
-
-    # Build WTF segments
-    wtf_segments = []
-    for i, seg in enumerate(segments):
-        wtf_seg = {
-            "id": seg.get("id", i),
-            "start": float(seg.get("start", seg.get("start_time", 0.0))),
-            "end": float(seg.get("end", seg.get("end_time", 0.0))),
-            "text": seg.get("text", seg.get("transcription", "")),
-            "confidence": float(seg.get("confidence", 0.9)),
-        }
-        if "speaker" in seg:
-            wtf_seg["speaker"] = seg["speaker"]
-        wtf_segments.append(wtf_seg)
-
-    # Build speakers section
-    speakers = {}
-    for seg in wtf_segments:
-        speaker = seg.get("speaker")
-        if speaker is not None:
-            speaker_key = str(speaker)
-            if speaker_key not in speakers:
-                speakers[speaker_key] = {
-                    "id": speaker,
-                    "label": f"Speaker {speaker}",
-                    "segments": [],
-                    "total_time": 0.0,
-                }
-            speakers[speaker_key]["segments"].append(seg["id"])
-            speakers[speaker_key]["total_time"] += seg["end"] - seg["start"]
-
-    # Build WTF body
-    wtf_body = {
-        "transcript": {
-            "text": full_text,
-            "language": language,
-            "duration": float(duration),
-            "confidence": float(avg_confidence),
-        },
-        "segments": wtf_segments,
-        "metadata": {
-            "created_at": now,
-            "processed_at": now,
-            "provider": "vfun",
-            "model": "parakeet-tdt-110m",
-            "audio": {
-                "duration": float(duration),
-            },
-        },
-        "quality": {
-            "average_confidence": float(avg_confidence),
-            "multiple_speakers": len(speakers) > 1,
-            "low_confidence_words": sum(1 for s in wtf_segments if s.get("confidence", 1.0) < 0.5),
-        },
-    }
-
-    if speakers:
-        wtf_body["speakers"] = speakers
+    vfun returns a WTF-compliant body directly. If language is set in
+    config, it is added to the transcript object.
+    """
+    if language and "transcript" in vfun_response:
+        vfun_response["transcript"]["language"] = language
 
     return {
         "type": "wtf_transcription",
         "dialog": dialog_index,
         "mediatype": "application/json",
         "vendor": "vfun",
-        "product": "parakeet-tdt-110m",
         "schema": "wtf-1.0",
-        # Note: encoding omitted since body is a direct object, not a JSON string
-        "body": wtf_body,
+        "body": vfun_response,
     }
 
 
@@ -247,7 +156,7 @@ def run(
     dialogs_skipped = 0
 
     for i, dialog in enumerate(vcon.dialog):
-        if not should_transcribe_dialog(dialog, opts.get("min-duration", 5)):
+        if not should_transcribe_dialog(dialog, opts.get("min-duration", 0)):
             logger.debug(f"Skipping dialog {i} (not eligible)")
             dialogs_skipped += 1
             continue
@@ -278,11 +187,13 @@ def run(
             mimetype = dialog.get("mimetype", "audio/wav")
 
             # Send audio to vfun server
-            files = {"file": (filename, audio_content, mimetype)}
+            files = {"file-binary": (filename, audio_content, mimetype)}
             data = {
-                "diarize": str(opts.get("diarize", True)),
-                "block": "true",
+                "diarize": str(opts.get("diarize", True)).lower(),
             }
+            language = opts.get("language")
+            if language:
+                data["language"] = language
 
             response = requests.post(
                 vfun_server_url,
@@ -292,14 +203,13 @@ def run(
                 timeout=opts.get("timeout", 300),
             )
 
-            if response.status_code in (200, 302):
+            if response.status_code == 200:
                 vfun_response = response.json()
                 # Handle double-encoded JSON (vfun sometimes returns JSON string)
                 if isinstance(vfun_response, str):
                     vfun_response = json.loads(vfun_response)
 
-                duration = dialog.get("duration", 30.0)
-                wtf_analysis = create_wtf_analysis(i, vfun_response, float(duration))
+                wtf_analysis = create_wtf_analysis(i, vfun_response, language=opts.get("language"))
 
                 # Add analysis to vCon
                 vcon.add_analysis(
@@ -309,7 +219,6 @@ def run(
                     body=wtf_analysis["body"],
                     extra={
                         "mediatype": wtf_analysis.get("mediatype"),
-                        "product": wtf_analysis.get("product"),
                         "schema": wtf_analysis.get("schema"),
                     },
                 )

--- a/docs/operations/monitoring.md
+++ b/docs/operations/monitoring.md
@@ -145,6 +145,126 @@ service:
       exporters: [prometheus]
 ```
 
+### Langfuse Integration
+
+Langfuse accepts traces via the standard OTLP HTTP endpoint — no separate collector needed.
+
+#### Step 1 — Generate your auth header
+
+In Langfuse, go to **Settings → API Keys** and copy your Public Key and Secret Key. Then run:
+
+```bash
+echo -n "pk-lf-YOUR_PUBLIC_KEY:sk-lf-YOUR_SECRET_KEY" | base64
+```
+
+Copy the output for the next step.
+
+#### Step 2 — Set environment variables
+
+Add the following to your `.env` file:
+
+```bash
+OTEL_EXPORTER_OTLP_ENDPOINT=http://<your-langfuse-host>:3000/api/public/otel
+OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
+OTEL_EXPORTER_OTLP_HEADERS=Authorization=Basic <output_from_step_1>
+```
+
+For Langfuse Cloud use:
+
+```bash
+OTEL_EXPORTER_OTLP_ENDPOINT=https://cloud.langfuse.com/api/public/otel
+```
+
+Traces will appear in Langfuse under the service names `conserver` and `api`.
+
+### Sending to Multiple Backends (Fan-out via OTel Collector)
+
+vCon Server can only point to one OTLP endpoint via environment variables. To fan out to multiple backends simultaneously, use the OTel Collector as a proxy. The example below uses SigNoz and Langfuse, but the same pattern works with any two OTLP-compatible backends.
+
+```
+vcon-server ──OTLP──▶ OTel Collector ──▶ Backend A (gRPC :4317)
+                                      └──▶ Backend B (HTTP)
+```
+
+#### Step 1 — Point vCon Server at the collector
+
+In your `.env`:
+
+```bash
+OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4317
+OTEL_EXPORTER_OTLP_PROTOCOL=grpc
+```
+
+No auth header needed here — the collector handles authentication to each backend separately.
+
+#### Step 2 — Add the collector to docker-compose.yml
+
+```yaml
+services:
+  otel-collector:
+    image: otel/opentelemetry-collector-contrib:latest
+    command: ["--config=/etc/otel-collector-config.yaml"]
+    volumes:
+      - ./otel-collector-config.yaml:/etc/otel-collector-config.yaml
+    ports:
+      - "4317:4317"
+    networks:
+      - conserver
+```
+
+> Use `otel/opentelemetry-collector-contrib` (not the slim `otel/opentelemetry-collector`) — it includes the `otlphttp` exporter needed for Langfuse.
+
+#### Step 3 — Configure the collector (otel-collector-config.yaml)
+
+Generate your Langfuse Basic auth token first:
+
+```bash
+echo -n "pk-lf-YOUR_PUBLIC_KEY:sk-lf-YOUR_SECRET_KEY" | base64
+```
+
+Then create `otel-collector-config.yaml`:
+
+```yaml
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+
+processors:
+  batch:
+
+exporters:
+  # SigNoz — receives OTLP gRPC
+  otlp/signoz:
+    endpoint: <your-signoz-host>:4317
+    tls:
+      insecure: true
+
+  # Langfuse — receives OTLP HTTP
+  otlphttp/langfuse:
+    endpoint: http://<your-langfuse-host>:3000/api/public/otel
+    headers:
+      Authorization: "Basic <base64_from_above>"
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [otlp/signoz, otlphttp/langfuse]
+    metrics:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [otlp/signoz]
+```
+
+> Langfuse only ingests **traces** (LLM spans). Metrics go to SigNoz only.
+
+Traces will appear in both backends. In Langfuse, look under service names `conserver` and `api`.
+
+---
+
 ## Prometheus Integration
 
 ### Metrics Endpoint


### PR DESCRIPTION
## Summary

Backports 7 commits from `main` (up to `5f3350c`) into the `optimize-docker-images` split layout, adapting all file paths and imports from the old `server/` structure.

- **New** `common/lib/openai_client.py` — shared `get_openai_client()` / `get_async_openai_client()` supporting OpenAI, Azure OpenAI, and LiteLLM proxy; all links/storage now call this instead of constructing clients inline
- **deepgram_link** — add LiteLLM proxy transcription path (`transcribe_via_litellm`), fix fd leak in audio temp file handling, make confidence check optional (not available on LiteLLM path)
- **wtf_transcribe** — updated for new vfun `/wtf` API: simplified `create_wtf_analysis` (pass response body directly), `file-binary` field name, `language` option, `diarize` default→`False`, `min-duration` default→`0`, accept status `200` only
- **api** — `/config` endpoint uses `Configuration.get_config()` instead of reading the YAML file directly
- **tests** — add `mock_get_client` patches to `analyze_and_label` and `detect_engagement` tests; fix `test_external_ingress` to patch `api.index_vcon` instead of `api.index_vcon_parties`
- **docs** — add Langfuse integration and OTel Collector fan-out documentation to `monitoring.md`
- **.gitignore** — add `litellm_config.yaml` (local dev file with credentials, was untracked)

## Test plan

- [ ] Run existing test suite via `docker compose run --rm conserver poetry run pytest`
- [ ] Verify `/config` endpoint returns config correctly
- [ ] Verify deepgram transcription works with both direct Deepgram key and LiteLLM proxy
- [ ] Verify wtf_transcribe works against updated vfun `/wtf` endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)