### PR TITLE
test: add integration tests for invalid vCon rejection

### DIFF
--- a/common/tests/invalid_fixtures/bad_dialog_types.json
+++ b/common/tests/invalid_fixtures/bad_dialog_types.json
@@ -1,0 +1,23 @@
+{
+  "uuid": "55555555-5555-5555-5555-555555555555",
+  "vcon": "0.0.1",
+  "meta": {
+    "duration": "eighteen",
+    "direction": "out",
+    "tenant_id": "test-tenant",
+    "disposition": "Bad Number",
+    "call_started_on": "NOT-A-DATE"
+  },
+  "parties": [],
+  "dialog": [
+    {
+      "type": "recording",
+      "start": "2025-10-30T06:18:03.784872+00:00",
+      "parties": [1, 0],
+      "duration": "long",
+      "mimetype": 12345
+    }
+  ],
+  "analysis": [],
+  "created_at": "2025-10-30T06:20:43.653260+00:00"
+}

--- a/common/tests/invalid_fixtures/empty_vcon.json
+++ b/common/tests/invalid_fixtures/empty_vcon.json
@@ -1,0 +1,9 @@
+{
+  "uuid": "",
+  "vcon": "",
+  "meta": {},
+  "parties": [],
+  "dialog": [],
+  "analysis": [],
+  "created_at": ""
+}

--- a/common/tests/invalid_fixtures/invalid_dialog_url.json
+++ b/common/tests/invalid_fixtures/invalid_dialog_url.json
@@ -1,0 +1,40 @@
+{
+  "uuid": "66666666-6666-6666-6666-666666666666",
+  "vcon": "0.0.1",
+  "meta": {
+    "duration": 64,
+    "direction": "out",
+    "tenant_id": "test-tenant",
+    "disposition": "Transfer: Strolid Agent",
+    "call_started_on": "2025-08-28T20:03:49.440326Z"
+  },
+  "parties": [
+    {
+      "id": "agent@test.example",
+      "tel": "+10000000001",
+      "name": "Test Agent",
+      "role": "ai"
+    },
+    {
+      "id": "+10000000002",
+      "tel": "+10000000002",
+      "name": "Test Customer",
+      "role": "customer"
+    }
+  ],
+  "dialog": [
+    {
+      "alg": "SHA-512",
+      "url": "not_a_valid_url_$$##",
+      "type": "recording",
+      "start": "2025-08-28T20:03:49.440326+00:00",
+      "parties": [0, 1],
+      "duration": 64,
+      "mimetype": null,
+      "signature": "tooshort",
+      "originator": 0
+    }
+  ],
+  "analysis": [],
+  "created_at": "2025-08-28T20:04:55.691933+00:00"
+}

--- a/common/tests/invalid_fixtures/missing_uuid_and_vcon_version.json
+++ b/common/tests/invalid_fixtures/missing_uuid_and_vcon_version.json
@@ -1,0 +1,34 @@
+{
+  "meta": {
+    "duration": 18,
+    "direction": "out",
+    "tenant_id": "test-tenant",
+    "disposition": "Bad Number",
+    "call_started_on": "2025-10-30T06:18:03.784872+00:00"
+  },
+  "parties": [
+    {
+      "id": "+10000000001_None_test",
+      "tel": "+10000000001",
+      "name": "Test Customer",
+      "role": "customer"
+    },
+    {
+      "id": "agent@test.example",
+      "tel": "+10000000002",
+      "name": "Test Agent",
+      "role": "agent"
+    }
+  ],
+  "dialog": [
+    {
+      "type": "recording",
+      "start": "2025-10-30T06:18:03.784872+00:00",
+      "parties": [1, 0],
+      "duration": 18,
+      "mimetype": "application/wav"
+    }
+  ],
+  "analysis": [],
+  "created_at": "2025-10-30T06:20:43.653260+00:00"
+}

--- a/common/tests/invalid_fixtures/null_dialog_string_analysis.json
+++ b/common/tests/invalid_fixtures/null_dialog_string_analysis.json
@@ -1,0 +1,28 @@
+{
+  "uuid": "77777777-7777-7777-7777-777777777777",
+  "vcon": "0.0.1",
+  "meta": {
+    "duration": 64,
+    "direction": "out",
+    "tenant_id": "test-tenant",
+    "disposition": "Transfer: Strolid Agent",
+    "call_started_on": "2025-08-28T20:03:49.440326Z"
+  },
+  "parties": [
+    {
+      "id": "agent@test.example",
+      "tel": "+10000000001",
+      "name": "Test Agent",
+      "role": "ai"
+    },
+    {
+      "id": "+10000000002_customer@test.example_test",
+      "tel": "+10000000002",
+      "name": "Test Customer",
+      "role": "customer"
+    }
+  ],
+  "dialog": null,
+  "analysis": "This should be an array not a string",
+  "created_at": "2025-08-28T20:04:55.691933+00:00"
+}

--- a/common/tests/invalid_fixtures/null_parties.json
+++ b/common/tests/invalid_fixtures/null_parties.json
@@ -1,0 +1,23 @@
+{
+  "uuid": "88888888-8888-8888-8888-888888888888",
+  "vcon": "0.0.1",
+  "meta": {
+    "duration": "eighteen",
+    "direction": "out",
+    "tenant_id": "test-tenant",
+    "disposition": "Bad Number",
+    "call_started_on": "NOT-A-DATE"
+  },
+  "parties": null,
+  "dialog": [
+    {
+      "type": "recording",
+      "start": "2025-10-30T06:18:03.784872+00:00",
+      "parties": [1, 0],
+      "duration": "long",
+      "mimetype": 12345
+    }
+  ],
+  "analysis": [],
+  "created_at": "2025-10-30T06:20:43.653260+00:00"
+}

--- a/common/tests/invalid_fixtures/out_of_range_party_indices.json
+++ b/common/tests/invalid_fixtures/out_of_range_party_indices.json
@@ -1,0 +1,38 @@
+{
+  "uuid": "99999999-9999-9999-9999-999999999999",
+  "vcon": "0.0.1",
+  "meta": {
+    "duration": 247,
+    "direction": "in",
+    "tenant_id": "test-tenant",
+    "disposition": "Appointment Declined",
+    "call_started_on": "2025-07-21T12:53:55.703746+00:00"
+  },
+  "parties": [
+    {
+      "id": "+10000000001_None_test",
+      "tel": "+10000000001",
+      "name": "Test Customer",
+      "role": "customer"
+    },
+    {
+      "id": "agent@test.example",
+      "tel": "+10000000002",
+      "name": "Test Agent",
+      "role": "agent"
+    }
+  ],
+  "dialog": [
+    {
+      "type": "recording",
+      "start": "2025-07-21T12:53:55.703746+00:00",
+      "parties": [0, 5, 9],
+      "duration": 247,
+      "mimetype": "application/wav",
+      "url": "https://example.com/recording.wav",
+      "originator": 7
+    }
+  ],
+  "analysis": [],
+  "created_at": "2025-07-21T13:00:07.342407+00:00"
+}

--- a/common/tests/test_invalid_vcon_pipeline.py
+++ b/common/tests/test_invalid_vcon_pipeline.py
@@ -1,0 +1,40 @@
+"""Integration tests: invalid vCons must be rejected at the pipeline entry point.
+
+Any JSON file placed in the invalid_fixtures/ directory is automatically picked
+up and posted to the API. Every fixture is expected to be rejected with HTTP 422
+before it can enter the conserver pipeline.
+"""
+
+import json
+import os
+
+import pytest
+from fastapi.testclient import TestClient
+
+import api
+from settings import CONSERVER_API_TOKEN, CONSERVER_HEADER_NAME
+
+_INVALID_FIXTURES_DIR = os.path.join(os.path.dirname(__file__), "invalid_fixtures")
+
+_invalid_fixtures = [
+    f for f in os.listdir(_INVALID_FIXTURES_DIR) if f.endswith(".json")
+]
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("filename", _invalid_fixtures)
+def test_invalid_vcon_rejected_by_pipeline(filename):
+    """Invalid vCons must be rejected with 422 and never enter the pipeline."""
+    filepath = os.path.join(_INVALID_FIXTURES_DIR, filename)
+    with open(filepath) as f:
+        invalid_vcon = json.load(f)
+
+    token = CONSERVER_API_TOKEN or "default_token"
+    header = CONSERVER_HEADER_NAME or "X-API-Token"
+
+    with TestClient(app=api.app, headers={header: token}) as client:
+        response = client.post("/vcon", json=invalid_vcon)
+
+    assert response.status_code == 422, (
+        f"{filename} was not rejected — got {response.status_code}: {response.json()}"
+    )


### PR DESCRIPTION
Adds a parametrized integration test that POSTs each fixture in invalid_fixtures/ to the API and asserts HTTP 422. Runs automatically on every push to main and all PRs via the existing CI workflow.

New fixtures cover: empty fields, null parties/dialog/analysis, wrong field types (duration, mimetype), out-of-range party indices, and invalid URLs. All PII has been redacted from real-world samples.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds only test fixtures and an integration test asserting the `/vcon` endpoint returns 422 for malformed payloads; main impact is potential CI flakiness if the endpoint behavior or auth headers differ across environments.
> 
> **Overview**
> Adds an integration test (`common/tests/test_invalid_vcon_pipeline.py`) that discovers JSON fixtures in `common/tests/invalid_fixtures/`, POSTs each to `POST /vcon` using the configured API token header, and asserts the request is rejected with **HTTP 422**.
> 
> Introduces several *invalid vCon* fixtures covering empty required fields, missing `uuid`/`vcon` version, null `parties`/`dialog`, wrong field types, invalid dialog URLs/signatures, and out-of-range party indices to ensure bad payloads are blocked at the pipeline entry point.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2bc07d9c548f4ae41026805fda6cb07c1886f577. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->