### PR TITLE
docs(conserver): document CONSERVER_VCON_CONCURRENCY and worker scaling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,31 @@ CONSERVER_API_TOKEN=
 CONSERVER_CONFIG_FILE=
 LOGGING_CONFIG_FILE=server/logging_dev.conf
 
+# ── Worker concurrency ───────────────────────────────────────────────────────
+# Max vCons processed in parallel = CONSERVER_WORKERS × CONSERVER_VCON_CONCURRENCY
+#
+# CONSERVER_WORKERS — number of independent worker processes (default: 1).
+# Each worker is a separate OS process that polls Redis with BLPOP. Scales
+# CPU-bound work; choose based on available cores.
+CONSERVER_WORKERS=1
+#
+# CONSERVER_VCON_CONCURRENCY — per-worker in-flight vCon limit (default: 1).
+# When > 1, each worker dispatches popped vCons to a ThreadPoolExecutor of
+# this size, so up to N chains run in parallel inside a single worker. Useful
+# for I/O-bound chains (LLM, transcription, webhook, storage). Leave at 1 for
+# the original strict-serial behaviour.
+CONSERVER_VCON_CONCURRENCY=1
+#
+# CONSERVER_PARALLEL_STORAGE — write to all storage backends concurrently
+# (default: true). Independent of the two settings above; controls a separate
+# thread pool sized to the number of configured storages.
+CONSERVER_PARALLEL_STORAGE=true
+#
+# CONSERVER_START_METHOD — multiprocessing start method: fork | spawn |
+# forkserver. Leave blank for the platform default (fork on Linux, spawn on
+# macOS/Windows). Use "spawn" if fork causes issues with native libraries.
+CONSERVER_START_METHOD=
+
 
 # ── OpenTelemetry ─────────────────────────────────────────────────────────────
 # Leave OTEL_EXPORTER_OTLP_ENDPOINT blank to disable tracing.

--- a/docs/configuration/environment-variables.md
+++ b/docs/configuration/environment-variables.md
@@ -181,7 +181,7 @@ CONSERVER_HEADER_NAME=Authorization
 
 ### CONSERVER_WORKERS
 
-Number of worker processes to spawn.
+Number of worker **processes** to spawn. Each worker is a separate OS process that polls Redis with BLPOP and processes vCons independently.
 
 | Property | Value |
 |----------|-------|
@@ -198,8 +198,39 @@ CONSERVER_WORKERS=4
 ```
 
 !!! tip "Sizing Workers"
-    For I/O-bound workloads (transcription, API calls), set to CPU core count.
-    For CPU-bound workloads, set to CPU core count minus 1.
+    Scale `CONSERVER_WORKERS` based on CPU cores for CPU-bound workloads.
+    For I/O-bound workloads, prefer raising `CONSERVER_VCON_CONCURRENCY` first —
+    it gives you parallelism without the per-process memory cost.
+
+### CONSERVER_VCON_CONCURRENCY
+
+Maximum number of in-flight vCons **per worker process**. When > 1, each worker dispatches popped vCons to an internal `ThreadPoolExecutor` of this size, so multiple chains run in parallel inside a single worker.
+
+| Property | Value |
+|----------|-------|
+| **Required** | No |
+| **Default** | `1` (strict serial — original behaviour) |
+| **Minimum** | `1` |
+
+```bash
+# Strict serial (default)
+CONSERVER_VCON_CONCURRENCY=1
+
+# Up to 8 vCons running in parallel inside each worker
+CONSERVER_VCON_CONCURRENCY=8
+```
+
+!!! info "Total parallelism"
+    `CONSERVER_WORKERS` and `CONSERVER_VCON_CONCURRENCY` multiply:
+
+    ```
+    max parallel vCons = CONSERVER_WORKERS × CONSERVER_VCON_CONCURRENCY
+    ```
+
+    For example, `CONSERVER_WORKERS=4` with `CONSERVER_VCON_CONCURRENCY=8` allows up to **32 vCons** in flight simultaneously. See [Worker Configuration](workers.md) for sizing guidance.
+
+!!! warning "Thread safety"
+    Concurrency > 1 runs chain links in threads. Link code must be thread-safe and should release the GIL during I/O (standard HTTP/DB clients do). Modules that hold the GIL across long CPU work will block other in-flight vCons in the same worker.
 
 ### CONSERVER_PARALLEL_STORAGE
 

--- a/docs/configuration/workers.md
+++ b/docs/configuration/workers.md
@@ -2,6 +2,17 @@
 
 vCon Server supports multi-worker processing for improved throughput and parallel storage writes for faster persistence.
 
+Two environment variables together determine how many vCons can be processed in parallel:
+
+```
+max parallel vCons = CONSERVER_WORKERS × CONSERVER_VCON_CONCURRENCY
+```
+
+- **`CONSERVER_WORKERS`** — number of worker **processes** (separate OS processes, each polling Redis independently). Scales CPU-bound work.
+- **`CONSERVER_VCON_CONCURRENCY`** — number of in-flight vCons **per worker** (a `ThreadPoolExecutor` inside each worker). Scales I/O-bound work (LLM, transcription, webhooks, storage writes) without paying the per-process memory cost.
+
+A third variable, **`CONSERVER_PARALLEL_STORAGE`**, controls a separate thread pool used only for writing to multiple storage backends concurrently — it is independent of the two above.
+
 ## Architecture Overview
 
 ```mermaid
@@ -87,6 +98,48 @@ CONSERVER_WORKERS=$(($(nproc) - 1))
 # For 8GB system with other services:
 CONSERVER_WORKERS=4
 ```
+
+### CONSERVER_VCON_CONCURRENCY
+
+Controls how many vCons each worker process keeps in flight at once. When set above `1`, the worker dispatches each popped vCon to an internal `ThreadPoolExecutor` and back-pressures (waits before the next BLPOP) when the pool is full.
+
+```bash
+# Strict serial — one vCon at a time per worker (default)
+CONSERVER_VCON_CONCURRENCY=1
+
+# Up to 8 vCons running in parallel inside each worker
+CONSERVER_VCON_CONCURRENCY=8
+```
+
+| Value | Behaviour | Best For |
+|-------|-----------|----------|
+| `1` | Strict serial — original behaviour | CPU-bound chains, debugging |
+| `2-4` | Light in-process parallelism | Mixed workloads |
+| `4-16` | High in-process parallelism | I/O-bound chains (LLM, transcription, webhooks) |
+
+#### How it combines with CONSERVER_WORKERS
+
+The two settings multiply:
+
+```
+max parallel vCons = CONSERVER_WORKERS × CONSERVER_VCON_CONCURRENCY
+```
+
+| Workers | Concurrency | Max parallel vCons | Notes |
+|---------|-------------|--------------------|----|
+| `1` | `1` | 1 | Original single-threaded behaviour |
+| `4` | `1` | 4 | Multi-process only — good for CPU-bound work |
+| `1` | `8` | 8 | Single-process, threaded — good for I/O-bound chains |
+| `4` | `8` | 32 | Combined — high-throughput I/O-bound workloads |
+
+#### When to raise concurrency vs. workers
+
+- **Raise `CONSERVER_WORKERS`** when chains are CPU-bound (heavy local compute, audio processing without GPU offload) — more processes sidestep the Python GIL.
+- **Raise `CONSERVER_VCON_CONCURRENCY`** when chains are I/O-bound (waiting on LLM/transcription APIs, external webhooks, S3/Postgres writes) — threads share memory and avoid the cost of extra processes.
+- **Combine both** for mixed workloads. Start by saturating concurrency within a single worker, then add workers if CPU is still underused.
+
+!!! warning "GIL & thread safety"
+    Concurrency > 1 runs chain links in threads. Chain link code must be thread-safe and should release the GIL during I/O (most HTTP/DB clients do). Modules that hold the GIL across long CPU work will block other in-flight vCons in the same worker.
 
 ## Parallel Storage
 
@@ -273,8 +326,9 @@ docker compose logs conserver | grep -i "worker"
 ### Development
 
 ```bash
-# Single worker, verbose logging
+# Single worker, single in-flight vCon, verbose logging
 CONSERVER_WORKERS=1
+CONSERVER_VCON_CONCURRENCY=1
 CONSERVER_PARALLEL_STORAGE=true
 LOG_LEVEL=DEBUG
 ```
@@ -283,7 +337,9 @@ LOG_LEVEL=DEBUG
 
 ```bash
 # Multi-worker, memory-efficient
+# 8 workers × 4 in-flight = up to 32 vCons in parallel
 CONSERVER_WORKERS=8
+CONSERVER_VCON_CONCURRENCY=4
 CONSERVER_PARALLEL_STORAGE=true
 CONSERVER_START_METHOD=fork
 LOG_LEVEL=INFO
@@ -293,27 +349,42 @@ LOG_LEVEL=INFO
 
 ```bash
 # Multi-worker, safer start method
+# 4 workers × 4 in-flight = up to 16 vCons in parallel
 CONSERVER_WORKERS=4
+CONSERVER_VCON_CONCURRENCY=4
 CONSERVER_PARALLEL_STORAGE=true
 CONSERVER_START_METHOD=spawn
 LOG_LEVEL=INFO
 ```
 
-### High-Throughput
+### High-Throughput (I/O-Bound)
 
 ```bash
-# Maximum parallelism
-CONSERVER_WORKERS=16
+# Saturate I/O without exploding process count
+# 4 workers × 16 in-flight = up to 64 vCons in parallel
+CONSERVER_WORKERS=4
+CONSERVER_VCON_CONCURRENCY=16
 CONSERVER_PARALLEL_STORAGE=true
 CONSERVER_START_METHOD=fork
 TICK_INTERVAL=1000  # Check queues more frequently
 ```
 
+### High-Throughput (CPU-Bound)
+
+```bash
+# Maximise process count, keep per-worker concurrency low
+CONSERVER_WORKERS=16
+CONSERVER_VCON_CONCURRENCY=1
+CONSERVER_PARALLEL_STORAGE=true
+CONSERVER_START_METHOD=fork
+```
+
 ### Memory-Constrained
 
 ```bash
-# Balance workers with available memory
+# Few processes, lean on in-process threading for parallelism
 CONSERVER_WORKERS=2
+CONSERVER_VCON_CONCURRENCY=8
 CONSERVER_PARALLEL_STORAGE=true
 CONSERVER_START_METHOD=fork  # Use COW memory
 ```

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -108,7 +108,8 @@ chains:
 | `REDIS_URL` | `redis://localhost` | Redis connection |
 | `CONSERVER_API_TOKEN` | - | API authentication |
 | `CONSERVER_CONFIG_FILE` | `./example_config.yml` | Config file path |
-| `CONSERVER_WORKERS` | `1` | Worker processes |
+| `CONSERVER_WORKERS` | `1` | Worker processes (multiplies with `CONSERVER_VCON_CONCURRENCY`) |
+| `CONSERVER_VCON_CONCURRENCY` | `1` | In-flight vCons per worker (thread pool size) |
 | `CONSERVER_PARALLEL_STORAGE` | `true` | Parallel storage writes |
 | `CONSERVER_START_METHOD` | Platform default | Multiprocessing method |
 | `LOG_LEVEL` | `DEBUG` | Logging level |

--- a/example_config.yml
+++ b/example_config.yml
@@ -2,33 +2,11 @@
 # =============================================================================
 # vCon Server Configuration
 # =============================================================================
-#
-# WORKER CONFIGURATION (via environment variables):
-#
-# CONSERVER_WORKERS: Number of worker processes (default: 1)
-#   - Set to 1 for single-threaded mode (original behavior)
-#   - Set to 2+ for multi-worker mode (parallel vCon processing)
-#   - Each worker independently consumes from Redis queues
-#   - Redis BLPOP provides atomic work distribution
-#   Example: CONSERVER_WORKERS=4
-#
-# CONSERVER_PARALLEL_STORAGE: Enable parallel storage writes (default: true)
-#   - When true, writes to multiple storage backends happen concurrently
-#   - Improves throughput when using multiple storage backends (e.g., S3 + MongoDB)
-#   - Set to "false" to use sequential storage writes
-#   Example: CONSERVER_PARALLEL_STORAGE=true
-#
-# CONSERVER_START_METHOD: Multiprocessing start method (default: platform default)
-#   - "fork": Copy-on-write memory sharing, fastest startup (Unix only)
-#     - Lower memory usage due to copy-on-write
-#     - Can cause issues with threads and some libraries (OpenSSL, CUDA)
-#   - "spawn": Fresh Python interpreter per worker
-#     - Higher memory but safer and more predictable
-#     - Required on Windows, recommended for macOS
-#   - "forkserver": Hybrid approach using a clean forked server process
-#   - "" or unset: Use Python's platform default
-#   Example: CONSERVER_START_METHOD=spawn
-#
+# This file configures the processing pipeline: chains, links, storages, and
+# ingress authentication. Server-level runtime knobs (worker count, vCon
+# concurrency, parallel storage, multiprocessing start method, etc.) are set
+# via environment variables — see .env.example and
+# docs/configuration/environment-variables.md.
 # =============================================================================
 
 # Ingress-specific API key authentication


### PR DESCRIPTION
## Summary
- Document the new `CONSERVER_VCON_CONCURRENCY` env var alongside the existing `CONSERVER_WORKERS` so operators can find the I/O-bound scaling lever without reading source.
- The two knobs multiply: `max parallel vCons = CONSERVER_WORKERS × CONSERVER_VCON_CONCURRENCY`. `CONSERVER_WORKERS` scales CPU-bound work via separate processes; `CONSERVER_VCON_CONCURRENCY` scales I/O-bound work via a per-worker thread pool.
- Clean up `example_config.yml`: that file is for pipeline configuration (chains, links, storages, ingress auth), not server-runtime env vars — point readers to `.env.example` and the env-var docs instead.

## Files changed
- `.env.example` — new worker-concurrency block covering the four related vars (`CONSERVER_WORKERS`, `CONSERVER_VCON_CONCURRENCY`, `CONSERVER_PARALLEL_STORAGE`, `CONSERVER_START_METHOD`)
- `docs/configuration/workers.md` — header explainer, dedicated `CONSERVER_VCON_CONCURRENCY` section with sizing table and a GIL/thread-safety note, refreshed Configuration Examples
- `docs/configuration/environment-variables.md` — new `CONSERVER_VCON_CONCURRENCY` entry between Workers and Parallel Storage
- `docs/reference/index.md` — added to the quick-reference table
- `example_config.yml` — drop env-var documentation; replace with a one-paragraph pointer

## Test plan
- [ ] Render `docs/` locally with `mkdocs serve` and verify the new variable appears under Configuration → Workers and Configuration → Environment Variables
- [ ] Confirm `example_config.yml` still parses (`python -c "import yaml; yaml.safe_load(open('example_config.yml'))"`)
- [ ] No behavioural changes — docs and examples only

🤖 Generated with [Claude Code](https://claude.com/claude-code)