### PR TITLE
fix(conserver): storage fallback for missing vCons + halt observability

### DIFF
--- a/common/lib/vcon_redis.py
+++ b/common/lib/vcon_redis.py
@@ -1,23 +1,35 @@
 import json
+from datetime import datetime
 from typing import Any, Optional
+from config import Configuration
 from lib.logging_utils import init_logger
 from lib.metrics import increment_counter
 from lib.vcon_compat import normalize_legacy_fields
 from redis.commands.json.path import Path
 from redis_mgr import redis
-from settings import VCON_REDIS_EXPIRY
+from settings import (
+    VCON_REDIS_EXPIRY,
+    VCON_SORTED_SET_NAME,
+    VCON_STORAGE_FALLBACK_ENABLED,
+)
+from storage.base import Storage
 import vcon
 
 logger = init_logger(__name__)
 
 
 class VconRedis:
-    """Encapsulate vcon redis operations with optional TTL support.
-    
-    This class provides both synchronous and asynchronous methods for storing
-    and retrieving vCon objects from Redis. TTL (Time-To-Live) can be set
-    on stored vCons to enable automatic expiration.
-    
+    """vCon access layer backed by Redis with optional storage fallback.
+
+    Reads go through Redis first (hot cache). On a miss, ``get_vcon`` /
+    ``get_vcon_dict`` fall back to the configured storage backends (see
+    ``Configuration.get_storages()``) and re-cache the first hit back into
+    Redis with TTL ``VCON_REDIS_EXPIRY``. The fallback is on by default and
+    can be disabled with ``VCON_STORAGE_FALLBACK_ENABLED=false``.
+
+    Writes go to Redis only; persistence to the storage backends is the
+    responsibility of the storage chain (e.g. via the ``Storage`` link).
+
     Attributes:
         DEFAULT_TTL: Default TTL in seconds from VCON_REDIS_EXPIRY setting (3600s).
     """
@@ -88,27 +100,76 @@ class VconRedis:
             redis.expire(key, ttl)
             logger.debug(f"Set TTL of {ttl}s on vCon {vCon.uuid}")
 
-    def get_vcon(self, vcon_id: str) -> Optional[vcon.Vcon]:
-        """Retrieves the vcon from redis for given vcon_id.
+    @staticmethod
+    def _load_from_storage(vcon_id: str) -> Optional[dict]:
+        """Try each configured storage backend in turn; return the first hit.
 
-        Args:
-            vcon_id (str): vcon id
+        Returns None if the fallback is disabled by setting, no storages are
+        configured, or none of them have the vCon. Per-backend errors are
+        logged but do not abort the loop — a later backend may succeed.
+        """
+        if not VCON_STORAGE_FALLBACK_ENABLED:
+            return None
+        storages = Configuration.get_storages()
+        if not storages:
+            return None
+        for storage_name in storages:
+            try:
+                vcon_dict = Storage(storage_name=storage_name).get(vcon_id)
+            except Exception as e:
+                logger.warning(
+                    "Storage fallback %s raised while loading vCon %s: %s",
+                    storage_name, vcon_id, e,
+                )
+                continue
+            if vcon_dict:
+                logger.info(
+                    "vCon %s missed Redis but recovered from storage %s",
+                    vcon_id, storage_name,
+                )
+                return vcon_dict
+        return None
+
+    def _cache_back_to_redis(self, vcon_id: str, vcon_dict: dict) -> None:
+        """Re-cache a storage-loaded vCon into Redis with the standard TTL and
+        re-add it to the sorted set so subsequent listings see it.
+
+        Reuses ``store_vcon_dict`` for the set+expire combo (which also runs
+        the spec-enforcement pass), then mirrors ``api.api.add_vcon_to_set``
+        synchronously. Any error is swallowed — the caller still gets the
+        vCon back.
+        """
+        try:
+            self.store_vcon_dict(vcon_dict, ttl=VCON_REDIS_EXPIRY)
+        except Exception as e:
+            logger.warning("Failed to re-cache vCon %s into Redis: %s", vcon_id, e)
+            return
+        created_at = vcon_dict.get("created_at")
+        if not created_at:
+            return
+        try:
+            timestamp = int(datetime.fromisoformat(str(created_at)).timestamp())
+            redis.zadd(VCON_SORTED_SET_NAME, {vcon_id: timestamp})
+        except (ValueError, TypeError) as e:
+            logger.debug(
+                "Skipping sorted-set add for vCon %s (created_at=%r): %s",
+                vcon_id, created_at, e,
+            )
+
+    def get_vcon(self, vcon_id: str) -> Optional[vcon.Vcon]:
+        """Retrieve a vCon by id, falling back to storage on a Redis miss.
+
+        Thin wrapper around :meth:`get_vcon_dict` that wraps the result in a
+        ``vcon.Vcon`` object. See :meth:`get_vcon_dict` for lookup semantics.
 
         Returns:
-            Optional[vcon.Vcon]: Returns vcon for given vcon id or None if vcon is not present.
+            The vCon if found in Redis or any storage, otherwise ``None``.
+            ``None`` is the contract for "halt the chain" in conserver links.
         """
-        vcon_dict = redis.json().get(
-            f"vcon:{vcon_id}", Path.root_path()
-        )
-        if not vcon_dict:
-            increment_counter("conserver.lib.vcon_redis.get_vcon_not_found")
+        vcon_dict = self.get_vcon_dict(vcon_id)
+        if vcon_dict is None:
             return None
-        # Tolerate legacy field names from older writers so links always
-        # see spec-compliant data; spec-correct writes are produced via
-        # vcon-lib 0.9.2 and the wrapper helpers.
-        normalize_legacy_fields(vcon_dict)
-        _vcon = vcon.Vcon(vcon_dict)
-        return _vcon
+        return vcon.Vcon(vcon_dict)
 
     def store_vcon_dict(self, vcon_dict: dict, ttl: Optional[int] = None) -> None:
         """Stores a vcon dictionary into redis with optional TTL.
@@ -126,19 +187,34 @@ class VconRedis:
             logger.debug(f"Set TTL of {ttl}s on vCon {vcon_dict['uuid']}")
 
     def get_vcon_dict(self, vcon_id: str) -> Optional[dict]:
-        """Retrieves a vcon dictionary from redis.
-        
+        """Retrieve a vCon dict by id, falling back to storage on a Redis miss.
+
+        Lookup order:
+          1. Redis (hot cache) — fast path.
+          2. Configured storage backends, in iteration order; on first hit
+             the vCon is re-cached into Redis with ``VCON_REDIS_EXPIRY``.
+
+        Legacy field names from older writers are normalized so callers
+        always see spec-compliant data.
+
         Args:
-            vcon_id (str): The vCon UUID.
-            
+            vcon_id: The vCon UUID.
+
         Returns:
-            Optional[dict]: The vCon as a dictionary, or None if not found.
+            The vCon as a dictionary if found, otherwise ``None``.
         """
         vcon_dict = redis.json().get(
             f"vcon:{vcon_id}", Path.root_path()
         )
-        if vcon_dict:
-            normalize_legacy_fields(vcon_dict)
+        if not vcon_dict:
+            increment_counter("conserver.lib.vcon_redis.get_vcon_redis_miss")
+            vcon_dict = self._load_from_storage(vcon_id)
+            if not vcon_dict:
+                increment_counter("conserver.lib.vcon_redis.get_vcon_not_found")
+                return None
+            increment_counter("conserver.lib.vcon_redis.get_vcon_storage_hit")
+            self._cache_back_to_redis(vcon_id, vcon_dict)
+        normalize_legacy_fields(vcon_dict)
         return vcon_dict
 
     def set_expiry(self, vcon_id: str, ttl: int) -> bool:

--- a/common/settings.py
+++ b/common/settings.py
@@ -37,6 +37,13 @@ VCON_INDEX_EXPIRY = int(os.getenv("VCON_INDEX_EXPIRY", 86400))
 # This improves performance for subsequent requests for the same vCon.
 VCON_REDIS_EXPIRY = int(os.getenv("VCON_REDIS_EXPIRY", 3600))
 
+# When VconRedis.get_vcon misses Redis, try configured storage backends in turn
+# and re-cache the first hit back into Redis. Set to "false" to keep the legacy
+# Redis-only behavior (callers receive None on Redis miss).
+VCON_STORAGE_FALLBACK_ENABLED = os.getenv(
+    "VCON_STORAGE_FALLBACK_ENABLED", "true"
+).lower() in ("true", "1", "yes")
+
 # Context expiration time in seconds (default 1 day)
 # Context data stored for ingress operations will expire after this time
 # to prevent memory leaks when the same vCon UUID is added multiple times.

--- a/conserver/links/deepgram_link/__init__.py
+++ b/conserver/links/deepgram_link/__init__.py
@@ -212,6 +212,9 @@ def run(
 
     vcon_redis = VconRedis()
     vCon = vcon_redis.get_vcon(vcon_uuid)
+    if vCon is None:
+        logger.error(f"deepgram: vCon {vcon_uuid} not found in Redis or storage; halting chain")
+        return None
     logger.debug(f"Loaded vCon {vcon_uuid} with {len(vCon.dialog)} dialogs.")
 
     for index, dialog in enumerate(vCon.dialog):

--- a/conserver/links/deepgram_link/tests/test_deepgram.py
+++ b/conserver/links/deepgram_link/tests/test_deepgram.py
@@ -41,6 +41,20 @@ def test_run_skips_non_recording_and_short_and_no_url(mock_transcribe, mock_dg, 
         assert instance.store_vcon.called
         assert result == vcon_uuid
 
+def test_run_halts_chain_when_vcon_not_found():
+    """If VconRedis returns None (vCon missing from Redis and every
+    storage backend), run() must return None — the chain-halt contract —
+    rather than dereferencing the None and crashing (CONSERVER-B7)."""
+    with patch('links.deepgram_link.VconRedis', autospec=True) as mock:
+        instance = MagicMock()
+        instance.get_vcon.return_value = None
+        mock.return_value = instance
+        opts = {"DEEPGRAM_KEY": "test", "minimum_duration": 60, "api": {}}
+        result = run("missing-uuid", "deepgram", opts)
+        assert result is None
+        assert not instance.store_vcon.called
+
+
 @patch('links.deepgram_link.DeepgramClient')
 @patch('links.deepgram_link.transcribe_dg')
 def test_run_skips_already_transcribed(mock_transcribe, mock_dg, vcon_with_transcript):

--- a/conserver/main.py
+++ b/conserver/main.py
@@ -615,7 +615,10 @@ class VconChainRequest:
                 )
                 increment_counter(
                     "conserver.link.count",
-                    attributes={"link_name": link_name, "outcome": "success"},
+                    attributes={
+                        "link_name": link_name,
+                        "outcome": "success" if should_continue_chain else "halt",
+                    },
                 )
                 logger.info(
                     "Completed link %s (module: %s) for vCon: %s in %s seconds",

--- a/conserver/tests/test_link_metrics.py
+++ b/conserver/tests/test_link_metrics.py
@@ -599,3 +599,35 @@ class TestMainLoopMetrics:
                                  {"chain.name": self.CHAIN_NAME})
         assert_metric_has_attrs(metrics, "conserver.main_loop.count_vcons_processed",
                                  {"chain.name": self.CHAIN_NAME})
+        # Link succeeded (returned uuid) — outcome="success".
+        assert_metric_has_attrs(metrics, "conserver.link.count",
+                                 {"link_name": "mock_link", "outcome": "success"})
+
+    def test_link_halt_records_halt_outcome(self, metric_reader):
+        """When a link returns None (halts the chain), the link.count counter
+        is incremented with outcome=halt rather than outcome=success."""
+        from main import VconChainRequest
+        import main as main_module
+
+        chain_details = {
+            "name": self.CHAIN_NAME,
+            "links": ["mock_link"],
+            "storages": [],
+            "egress_lists": [],
+        }
+        main_module.config = {
+            "links": {
+                "mock_link": {"module": "mock_module", "options": {}},
+            }
+        }
+
+        mock_module = MagicMock()
+        mock_module.run.return_value = None  # halt chain
+
+        with patch.dict("main.imported_modules", {"mock_module": mock_module}):
+            req = VconChainRequest(chain_details, self.UUID, context=None)
+            req.process()
+
+        metrics = extract_metrics(metric_reader)
+        assert_metric_has_attrs(metrics, "conserver.link.count",
+                                 {"link_name": "mock_link", "outcome": "halt"})

--- a/tests/core/test_vcon_redis.py
+++ b/tests/core/test_vcon_redis.py
@@ -71,3 +71,143 @@ def test_get_vcon_dict(mock_redis):
     loaded_vcon_dict = vcon_redis.get_vcon_dict(vcon_dict["uuid"])
 
     assert vcon_dict == loaded_vcon_dict
+
+
+# ---------------------------------------------------------------------------
+# Storage fallback path (CONSERVER-B7)
+# ---------------------------------------------------------------------------
+
+
+def _miss_then_hit_redis(mock_redis, storage_dict):
+    """Configure the mocked redis client so .json().get() returns None
+    (Redis miss). Returns the mock_json handle so callers can assert on
+    re-cache writes."""
+    mock_json = MagicMock()
+    mock_json.get.return_value = None
+    mock_redis.json.return_value = mock_json
+    return mock_json
+
+
+@patch("lib.vcon_redis.Storage")
+@patch("lib.vcon_redis.Configuration")
+@patch("lib.vcon_redis.VCON_STORAGE_FALLBACK_ENABLED", True)
+@patch("lib.vcon_redis.redis")
+def test_get_vcon_redis_miss_storage_hit_recaches(
+    mock_redis, mock_config, mock_storage_cls
+):
+    vcon_dict = _load_sample_vcon_dict()
+    mock_json = _miss_then_hit_redis(mock_redis, vcon_dict)
+    mock_config.get_storages.return_value = {"s3": {}}
+
+    storage_instance = MagicMock()
+    storage_instance.get.return_value = vcon_dict
+    mock_storage_cls.return_value = storage_instance
+
+    loaded = VconRedis().get_vcon(vcon_dict["uuid"])
+
+    assert loaded is not None
+    assert loaded.uuid == vcon_dict["uuid"]
+    mock_storage_cls.assert_called_once_with(storage_name="s3")
+    storage_instance.get.assert_called_once_with(vcon_dict["uuid"])
+    # Re-cache happened: json().set and expire on the key, and sorted-set add.
+    assert mock_json.set.call_count == 1
+    mock_redis.expire.assert_called_once()
+    mock_redis.zadd.assert_called_once()
+
+
+@patch("lib.vcon_redis.Storage")
+@patch("lib.vcon_redis.Configuration")
+@patch("lib.vcon_redis.VCON_STORAGE_FALLBACK_ENABLED", True)
+@patch("lib.vcon_redis.redis")
+def test_get_vcon_redis_miss_storage_miss_returns_none(
+    mock_redis, mock_config, mock_storage_cls
+):
+    _miss_then_hit_redis(mock_redis, None)
+    mock_config.get_storages.return_value = {"s3": {}, "postgres": {}}
+    storage_instance = MagicMock()
+    storage_instance.get.return_value = None
+    mock_storage_cls.return_value = storage_instance
+
+    assert VconRedis().get_vcon("missing-uuid") is None
+    # Both backends were tried.
+    assert storage_instance.get.call_count == 2
+
+
+@patch("lib.vcon_redis.Storage")
+@patch("lib.vcon_redis.Configuration")
+@patch("lib.vcon_redis.VCON_STORAGE_FALLBACK_ENABLED", False)
+@patch("lib.vcon_redis.redis")
+def test_get_vcon_storage_fallback_disabled(
+    mock_redis, mock_config, mock_storage_cls
+):
+    _miss_then_hit_redis(mock_redis, None)
+
+    assert VconRedis().get_vcon("missing-uuid") is None
+    # Flag off: no storage iteration, no Storage instantiation.
+    mock_config.get_storages.assert_not_called()
+    mock_storage_cls.assert_not_called()
+
+
+@patch("lib.vcon_redis.Storage")
+@patch("lib.vcon_redis.Configuration")
+@patch("lib.vcon_redis.VCON_STORAGE_FALLBACK_ENABLED", True)
+@patch("lib.vcon_redis.redis")
+def test_get_vcon_first_storage_errors_second_succeeds(
+    mock_redis, mock_config, mock_storage_cls
+):
+    vcon_dict = _load_sample_vcon_dict()
+    _miss_then_hit_redis(mock_redis, vcon_dict)
+    mock_config.get_storages.return_value = {"broken": {}, "s3": {}}
+
+    broken = MagicMock()
+    broken.get.side_effect = RuntimeError("backend down")
+    good = MagicMock()
+    good.get.return_value = vcon_dict
+    mock_storage_cls.side_effect = [broken, good]
+
+    loaded = VconRedis().get_vcon(vcon_dict["uuid"])
+
+    assert loaded is not None
+    assert loaded.uuid == vcon_dict["uuid"]
+    assert mock_storage_cls.call_count == 2
+
+
+@patch("lib.vcon_redis.Storage")
+@patch("lib.vcon_redis.Configuration")
+@patch("lib.vcon_redis.VCON_STORAGE_FALLBACK_ENABLED", True)
+@patch("lib.vcon_redis.redis")
+def test_get_vcon_dict_falls_back_to_storage(
+    mock_redis, mock_config, mock_storage_cls
+):
+    vcon_dict = _load_sample_vcon_dict()
+    _miss_then_hit_redis(mock_redis, vcon_dict)
+    mock_config.get_storages.return_value = {"s3": {}}
+    storage_instance = MagicMock()
+    storage_instance.get.return_value = vcon_dict
+    mock_storage_cls.return_value = storage_instance
+
+    loaded = VconRedis().get_vcon_dict(vcon_dict["uuid"])
+
+    assert loaded is not None
+    assert loaded["uuid"] == vcon_dict["uuid"]
+    storage_instance.get.assert_called_once()
+
+
+@patch("lib.vcon_redis.Storage")
+@patch("lib.vcon_redis.Configuration")
+@patch("lib.vcon_redis.VCON_STORAGE_FALLBACK_ENABLED", True)
+@patch("lib.vcon_redis.redis")
+def test_get_vcon_redis_hit_skips_storage(
+    mock_redis, mock_config, mock_storage_cls
+):
+    """When Redis has the vCon, storage must not be touched at all."""
+    vcon_dict = _load_sample_vcon_dict()
+    mock_json = MagicMock()
+    mock_json.get.return_value = vcon_dict  # Redis hit
+    mock_redis.json.return_value = mock_json
+
+    loaded = VconRedis().get_vcon(vcon_dict["uuid"])
+
+    assert loaded is not None
+    mock_config.get_storages.assert_not_called()
+    mock_storage_cls.assert_not_called()


### PR DESCRIPTION
## Summary

Three small, layered changes addressing Sentry CONSERVER-B7 (`AttributeError: 'NoneType' object has no attribute 'dialog'` in `deepgram_link.run`):

1. **Storage fallback in `VconRedis`** — when a vCon is no longer in Redis (TTL expired or evicted), `get_vcon` / `get_vcon_dict` now iterate the configured storage backends, return the first hit, and re-cache it back into Redis with `VCON_REDIS_EXPIRY`. On by default; opt out with `VCON_STORAGE_FALLBACK_ENABLED=false`. This makes every link that calls `VconRedis.get_vcon` resilient to the "vCon UUID hits the chain after Redis TTL" pattern without per-link changes. `get_vcon` is also refactored to delegate to `get_vcon_dict` for a single lookup path.

2. **`deepgram_link` None-guard** — defense-in-depth for the case where the storage fallback also misses (or is disabled). Halts the chain cleanly per the docstring contract (`return None`) instead of dereferencing the missing vCon. Mirrors the existing guard pattern in `transcribe`, `tag_router`, `jq_link`, and `check_and_tag`.

3. **Halt-vs-success metric split** — `conserver.link.count` previously fired with `outcome="success"` for both "return uuid" (continue) and "return None" (halt), making it impossible to track which links halt chains. Now uses `outcome="halt"` when the link returned a falsy value. Existing dashboards filtering on `outcome="success"` remain accurate; new dashboards can pivot on `outcome="halt"` with `link_name`.

Fixes CONSERVER-B7.

## Test plan

- [x] `pytest tests/core/test_vcon_redis.py` — 10 passing (4 pre-existing + 6 new fallback-path tests: Redis hit, Redis miss + storage hit (re-cache + sorted-set add), Redis miss + storage miss, fallback disabled, first-storage-errors-second-succeeds, dict-variant fallback)
- [x] `pytest tests/core/test_vcon_redis_ttl.py` — 24 passing (no regression)
- [x] `pytest conserver/links/deepgram_link/tests/` — 11 passing (1 new `test_run_halts_chain_when_vcon_not_found`)
- [x] `pytest conserver/tests/test_link_metrics.py conserver/tests/test_vcon_concurrency.py` — 34 passing (1 new `test_link_halt_records_halt_outcome`)

All tests run inside the `vcon-server-conserver-1` container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)