### PR TITLE
fix(openai-client): retry transient 5xx on embeddings calls

### DIFF
--- a/common/lib/openai_client.py
+++ b/common/lib/openai_client.py
@@ -18,12 +18,15 @@ logger = init_logger(__name__)
 DEFAULT_AZURE_OPENAI_API_VERSION = "2024-10-21"
 
 
-def get_openai_client(opts=None):
+def get_openai_client(opts=None, max_retries=0):
     """
     Return an OpenAI-compatible client (OpenAI or AzureOpenAI).
     Same client is used for chat and embeddings; LiteLLM proxy supports both.
 
     opts: dict of options. All values are read from opts only.
+    max_retries: SDK-level retry count for transient 5xx/429 from the
+      provider/proxy. Defaults to 0 to preserve existing behavior; callers
+      making idempotent requests (e.g. embeddings) should pass a small value.
 
     Supported keys in opts:
       - LITELLM_PROXY_URL, LITELLM_MASTER_KEY  -> use LiteLLM proxy (chat + embeddings)
@@ -46,7 +49,7 @@ def get_openai_client(opts=None):
             organization=organization if organization else None,
             project=project if project else None,
             timeout=120.0,
-            max_retries=0,
+            max_retries=max_retries,
         )
 
     azure_endpoint = (opts.get("AZURE_OPENAI_ENDPOINT") or "").strip()
@@ -60,7 +63,7 @@ def get_openai_client(opts=None):
             azure_endpoint=azure_endpoint,
             api_version=azure_api_version,
             timeout=120.0,
-            max_retries=0,
+            max_retries=max_retries,
         )
 
     openai_api_key = (
@@ -77,7 +80,7 @@ def get_openai_client(opts=None):
             organization=organization if organization else None,
             project=project if project else None,
             timeout=120.0,
-            max_retries=0,
+            max_retries=max_retries,
         )
 
     raise ValueError(

--- a/common/storage/milvus/__init__.py
+++ b/common/storage/milvus/__init__.py
@@ -446,8 +446,9 @@ def save(vcon_uuid: str, opts=default_options) -> None:
                 logger.info(f"vCon {vcon_uuid} already exists in Milvus collection {collection_name}, skipping")
                 return
         
-        # Initialize OpenAI client (supports LiteLLM proxy via LITELLM_PROXY_URL + LITELLM_MASTER_KEY provided in opts)
-        openai_client = get_openai_client(opts)
+        # Initialize OpenAI client (supports LiteLLM proxy via LITELLM_PROXY_URL + LITELLM_MASTER_KEY provided in opts).
+        # Embeddings are idempotent, so retry transient 5xx/429 from the proxy (Sentry CONSERVER-9G).
+        openai_client = get_openai_client(opts, max_retries=3)
 
         # Extract text content from vCon
         text = extract_text_from_vcon(vcon_dict)


### PR DESCRIPTION
## Summary
- The Milvus storage link calls OpenAI/LiteLLM embeddings through `get_openai_client()`, which constructs the SDK client with `max_retries=0`. Any transient upstream 503 from the proxy or provider (e.g. `upstream connect error … reset reason: connection termination`) therefore surfaces immediately as an unhandled `InternalServerError`.
- Embeddings requests are idempotent, so a small retry budget is safe and matches the failure mode (transient network/proxy hiccups with exponential backoff in the SDK).
- `get_openai_client(opts=None, max_retries=0)` now takes an explicit kwarg. Default of `0` preserves existing behavior for every other caller; the Milvus embeddings path passes `max_retries=3`.

## Test plan
- [ ] Unit/integration: `get_openai_client()` still constructs clients with `max_retries=0` when no override is passed.
- [ ] Milvus storage link end-to-end: embeddings call succeeds, and a simulated 503 retries instead of bubbling.
- [ ] Monitor Sentry issue for the embeddings error rate after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)