### PR TITLE
feat(metrics): emit conserver.dlq.count on DLQ writes

### DIFF
--- a/common/lib/queue.py
+++ b/common/lib/queue.py
@@ -33,6 +33,7 @@ async API.
 from typing import List, Optional, Tuple
 
 from lib.logging_utils import init_logger
+from lib.metrics import increment_counter
 
 logger = init_logger(__name__)
 
@@ -95,12 +96,17 @@ class VconQueue:
         convention stays in one place. Pairs with
         :meth:`dequeue_dlq_async` (LPOP) for FIFO (oldest-failure-first)
         ordering when draining the DLQ back to its ingress queue.
+
+        Emits ``conserver.dlq.count{queue_name}`` so observability stacks
+        can alert on any DLQ entry.
         """
         # Lazy import: dlq_utils lives under conserver/, not common/.
         from dlq_utils import get_ingress_list_dlq_name
 
         dlq_name = get_ingress_list_dlq_name(ingress_list)
-        return self._client.rpush(dlq_name, vcon_id)
+        result = self._client.rpush(dlq_name, vcon_id)
+        increment_counter("conserver.dlq.count", attributes={"queue_name": dlq_name})
+        return result
 
     def queue_length(self, list_name: str) -> int:
         return self._client.llen(list_name)

--- a/common/tests/test_queue_dlq_counter.py
+++ b/common/tests/test_queue_dlq_counter.py
@@ -1,0 +1,67 @@
+"""Unit tests for ``conserver.dlq.count`` emission from ``VconQueue.enqueue_dlq``.
+
+The counter is the only signal external monitoring (SignOz alert
+``vCons routed to DLQ``) has that vCons are failing the chain.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from lib.queue import VconQueue
+
+
+class TestEnqueueDlqEmitsCounter:
+    def test_emits_counter_with_queue_name_attribute(self):
+        """``enqueue_dlq`` emits ``conserver.dlq.count`` with the resolved DLQ
+        name as the ``queue_name`` attribute (not the bare ingress list)."""
+        mock_client = MagicMock()
+        mock_client.rpush.return_value = 1
+        q = VconQueue(client=mock_client)
+
+        with patch("lib.queue.increment_counter") as inc:
+            q.enqueue_dlq("transcribe", "vcon-uuid-1234")
+
+        inc.assert_called_once_with(
+            "conserver.dlq.count",
+            attributes={"queue_name": "DLQ:transcribe"},
+        )
+
+    def test_rpush_is_called_before_counter(self):
+        """If the RPUSH itself raises (e.g. Redis dead), the counter must
+        NOT increment — we only want to count actual DLQ entries."""
+        mock_client = MagicMock()
+        mock_client.rpush.side_effect = RuntimeError("redis down")
+        q = VconQueue(client=mock_client)
+
+        with patch("lib.queue.increment_counter") as inc:
+            with pytest.raises(RuntimeError):
+                q.enqueue_dlq("transcribe", "vcon-uuid-1234")
+
+        inc.assert_not_called()
+
+    def test_returns_rpush_result(self):
+        """The new code path must preserve the existing return value
+        contract (the new list length, per redis-py ``rpush``)."""
+        mock_client = MagicMock()
+        mock_client.rpush.return_value = 42
+        q = VconQueue(client=mock_client)
+
+        with patch("lib.queue.increment_counter"):
+            assert q.enqueue_dlq("transcribe", "vcon-uuid-1234") == 42
+
+    def test_counter_uses_dlq_name_for_each_ingress(self):
+        """Different ingress lists must produce different ``queue_name``
+        attributes, so the SignOz alert can group by ingress."""
+        mock_client = MagicMock()
+        mock_client.rpush.return_value = 1
+        q = VconQueue(client=mock_client)
+
+        with patch("lib.queue.increment_counter") as inc:
+            q.enqueue_dlq("transcribe", "v1")
+            q.enqueue_dlq("default", "v2")
+            q.enqueue_dlq("scitt_backfill", "v3")
+
+        assert inc.call_count == 3
+        seen = {call.kwargs["attributes"]["queue_name"] for call in inc.call_args_list}
+        assert seen == {"DLQ:transcribe", "DLQ:default", "DLQ:scitt_backfill"}


### PR DESCRIPTION
## Summary

Add a Counter metric increment to `VconQueue.enqueue_dlq` so monitoring stacks can observe when vCons are routed to the dead-letter queue.

The new counter is named `conserver.dlq.count` and carries a `queue_name` attribute set to the resolved DLQ name (e.g. `DLQ:transcribe`), matching the naming convention of the existing `conserver.storage.count` and `conserver.link.count` counters.

The emit lives inside `enqueue_dlq` itself rather than at the call site in `conserver/main.py` because the existing docstring on that method already documents it as the single RPUSH-onto-DLQ chokepoint — putting the counter here covers every present and future DLQ-write path with zero risk of being bypassed.

## Test plan

- [x] New `common/tests/test_queue_dlq_counter.py` covers:
  - counter is called with `conserver.dlq.count` and `queue_name=DLQ:<ingress>`
  - counter is NOT incremented if the underlying RPUSH raises (we don't want to count writes that didn't happen)
  - return value of `enqueue_dlq` still matches the RPUSH result (existing API preserved)
  - different ingress lists produce different `queue_name` attribute values
- [x] Existing `common/tests/test_dlq_expiry.py` still passes
- [ ] Manual verification on a running deployment: roll the new image, force a vCon failure, confirm `conserver.dlq.count` appears in your metrics backend with `queue_name=DLQ:<ingress>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)