### PR TITLE
feat(hook): honor before_processing return value to gate chain execution

### DIFF
--- a/conserver/hook.py
+++ b/conserver/hook.py
@@ -12,15 +12,20 @@ def before_processing(
     vcon_id: str,
     chain_details: Dict[str, Any],
     context: Optional[Dict[str, Any]],
-) -> None:
+) -> Optional[str]:
     """Called before processing of a vCon starts.
 
     Args:
         vcon_id: The vCon identifier.
         chain_details: The chain configuration for this processing run.
         context: Optional context data (e.g. trace_id, span_id).
+
+    Returns:
+        The vCon identifier to continue chain processing, or a falsy value
+        (None / False / "") to skip processing for this vCon without raising
+        and without sending it to the DLQ. Mirrors the link contract.
     """
-    pass
+    return vcon_id
 
 
 def after_processing(

--- a/conserver/main.py
+++ b/conserver/main.py
@@ -732,7 +732,12 @@ def _handle_vcon(
     try:
         context = context or {}
         context["ingress_list"] = ingress_list
-        hook.before_processing(vcon_id, chain_details, context)
+        if not hook.before_processing(vcon_id, chain_details, context):
+            logger.info(
+                "[%s] before_processing skipped vCon %s on ingress %s",
+                worker_name, vcon_id, ingress_list,
+            )
+            return
         vcon_chain_request.process()
     except Exception as e:
         processing_error = e


### PR DESCRIPTION
## Summary

Make `hook.before_processing` honor its return value the same way chain links do:

- Return the vcon_id (or any truthy value) → continue chain processing as before.
- Return `None` / `False` / `""` → skip the chain for this vCon. No exception, no DLQ push. `after_processing` still runs in `finally`.

The default hook is updated to explicitly `return vcon_id` so the default behaviour is preserved.

## Motivation

Today the only way a hook can stop chain processing is to raise an exception, which the worker treats as a chain failure and pushes to the DLQ. That's the right behaviour for unexpected errors, but it conflates "the hook wants to defer this vCon" with "chain processing failed". Hooks that legitimately want to skip a vCon (for example, to defer it to a custom retry queue) had no way to do so without unwanted DLQ side effects.

This mirrors the existing chain-link `should_continue_chain` pattern (`module.run` returns the vcon_id to continue, falsy to halt) — so the contract is consistent for links and hooks.

## Breaking change

Hooks that previously relied on the implicit `None` return will now skip the chain instead of continuing. Custom `before_processing` implementations must explicitly `return vcon_id` for normal continuation. The bundled default hook is updated accordingly.

## Recommended release tag

`v2.0.0` (MAJOR bump from `v1.0.2`, per SemVer for a breaking contract change).

Suggested annotated-tag message:

```text
v2.0.0

BREAKING CHANGE: hook.before_processing now uses its return value to gate chain execution.
Returning None (the previous implicit default) now causes the vCon to be skipped instead
of processed. Custom hooks must explicitly `return vcon_id` for normal continuation.

See #172.
```

## Test plan

- [ ] Run conserver test suite inside Docker (`docker exec ... pytest`)
- [ ] Default hook: vCon processes normally end-to-end (chain runs, storage writes, no DLQ on success, DLQ on link exception)
- [ ] Custom hook returning None: `process()` is not called, no DLQ entry, `after_processing` still invoked with `error=None`

🤖 Generated with [Claude Code](https://claude.com/claude-code)