### PR TITLE
feat(vcon): add find_attachment_by_purpose, deprecate find_attachment_by_type

### DIFF
--- a/common/storage/elasticsearch/__init__.py
+++ b/common/storage/elasticsearch/__init__.py
@@ -75,7 +75,7 @@ def save(
             "started_at": started_at,
         }
 
-        tenant_attachment = vcon.find_attachment_by_type("tenant")
+        tenant_attachment = vcon.find_attachment_by_purpose("tenant")
         if tenant_attachment:
             if tenant_attachment["encoding"] == "json" and isinstance(tenant_attachment["body"], str):
                 tenant = json.loads(tenant_attachment["body"])

--- a/common/tests/test_encoding.py
+++ b/common/tests/test_encoding.py
@@ -29,7 +29,7 @@ def test_encoding():
             body= "String value",
             encoding= "none",
     )
-    assert test_vcon.find_attachment_by_type("test_encoding_str") == {
+    assert test_vcon.find_attachment_by_purpose("test_encoding_str") == {
         "type": "test_encoding_str",
         "body": "String value",
         "encoding": "none",
@@ -41,7 +41,7 @@ def test_encoding():
             encoding= "json",
         
     )
-    assert test_vcon.find_attachment_by_type("test_encoding_json") == {
+    assert test_vcon.find_attachment_by_purpose("test_encoding_json") == {
         "type": "test_encoding_json",
         "body": json.dumps({"key": "value"}),
         "encoding": "json",

--- a/common/vcon.py
+++ b/common/vcon.py
@@ -1,5 +1,6 @@
 import copy
 import json
+import warnings
 from typing import Optional, Union
 import hashlib
 import time
@@ -39,10 +40,10 @@ class Vcon:
 
     @property
     def tags(self):
-        return self.find_attachment_by_type("tags")
+        return self.find_attachment_by_purpose("tags")
 
     def get_tag(self, tag_name):
-        tags_attachment = self.find_attachment_by_type("tags")
+        tags_attachment = self.find_attachment_by_purpose("tags")
         if not tags_attachment:
             return None
         tag = next(
@@ -54,7 +55,7 @@ class Vcon:
         return tag_value
 
     def add_tag(self, tag_name, tag_value):
-        tags_attachment = self.find_attachment_by_type("tags")
+        tags_attachment = self.find_attachment_by_purpose("tags")
         if not tags_attachment:
             tags_attachment = {
                 "type": "tags",
@@ -64,10 +65,34 @@ class Vcon:
             self.vcon_dict["attachments"].append(tags_attachment)
         tags_attachment["body"].append(f"{tag_name}:{tag_value}")
 
-    def find_attachment_by_type(self, type):
+    def find_attachment_by_purpose(self, purpose):
+        # IETF vCon spec 0.4.0 attachment lookup. Matches `purpose` first
+        # (spec-current key) and falls back to legacy `type` so attachments
+        # written by older producers still resolve. `.get` tolerates missing
+        # keys so a mixed-shape attachment list never raises KeyError.
         return next(
-            (a for a in self.vcon_dict["attachments"] if a["type"] == type), None
+            (
+                a
+                for a in self.vcon_dict["attachments"]
+                if a.get("purpose") == purpose or a.get("type") == purpose
+            ),
+            None,
         )
+
+    def find_attachment_by_type(self, type):
+        """Deprecated: use :meth:`find_attachment_by_purpose` instead.
+
+        Kept for callers written against the pre-spec-0.4.0 shape. Delegates
+        to ``find_attachment_by_purpose``, which already matches both `type`
+        and `purpose` keys for back-compat.
+        """
+        warnings.warn(
+            "Vcon.find_attachment_by_type is deprecated; use "
+            "Vcon.find_attachment_by_purpose (spec 0.4.0 renamed the field).",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.find_attachment_by_purpose(type)
 
     def add_attachment(self, *, body: Union[dict, list, str], type: str, encoding="none"):
         if encoding not in ['json', 'none', 'base64url']:

--- a/tests/core/test_vcon.py
+++ b/tests/core/test_vcon.py
@@ -1,4 +1,5 @@
 import pytest
+import warnings
 from vcon import Vcon
 import json
 
@@ -42,7 +43,7 @@ def test_tags():
 def test_add_attachment():
     vcon = Vcon.build_new()
     vcon.add_attachment(body={"key": "value"}, type="test_type")
-    attachment = vcon.find_attachment_by_type("test_type")
+    attachment = vcon.find_attachment_by_purpose("test_type")
     assert attachment["body"] == {"key": "value"}
 
 
@@ -86,10 +87,57 @@ def test_get_tag():
 
 
 def test_find_attachment_by_type():
+    # Deprecated alias — still works for callers written against pre-0.4.0
+    # vCon shape, finding attachments stored with the legacy `type` key.
     vcon = Vcon.build_new()
     vcon.add_attachment(body={"key": "value"}, type="test_type")
-    assert vcon.find_attachment_by_type("test_type") == {"type": "test_type", "body": {"key": "value"}, "encoding": "none"}
-    assert vcon.find_attachment_by_type("nonexistent_type") is None
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        assert vcon.find_attachment_by_type("test_type") == {
+            "type": "test_type",
+            "body": {"key": "value"},
+            "encoding": "none",
+        }
+        assert vcon.find_attachment_by_type("nonexistent_type") is None
+
+
+def test_find_attachment_by_type_emits_deprecation_warning():
+    vcon = Vcon.build_new()
+    vcon.add_attachment(body={"k": "v"}, type="x")
+    with pytest.warns(DeprecationWarning, match="find_attachment_by_purpose"):
+        vcon.find_attachment_by_type("x")
+
+
+def test_find_attachment_by_purpose_matches_purpose_key():
+    # IETF vCon spec 0.4.0 renamed `type` → `purpose` on attachments. The
+    # canonical lookup must find attachments authored by spec-current writers.
+    vcon = Vcon.build_new()
+    vcon.vcon_dict["attachments"].append(
+        {"purpose": "spec_current", "body": {"k": "v"}, "encoding": "none"}
+    )
+    found = vcon.find_attachment_by_purpose("spec_current")
+    assert found is not None
+    assert found.get("purpose") == "spec_current"
+
+
+def test_find_attachment_by_purpose_matches_legacy_type_key():
+    # Back-compat: an attachment stored under the old `type` key must still be
+    # discoverable via the new canonical lookup name. Mirrors how the Redis
+    # storage layer tolerates both shapes.
+    vcon = Vcon.build_new()
+    vcon.add_attachment(body={"k": "v"}, type="legacy")
+    assert vcon.find_attachment_by_purpose("legacy") is not None
+
+
+def test_find_attachment_by_purpose_tolerates_missing_keys():
+    # Some attachments in the wild are missing both `type` and `purpose`
+    # (e.g. encoding-only payloads from older link versions). Lookup must not
+    # raise KeyError — previously it did `a["type"]` and crashed the chain.
+    vcon = Vcon.build_new()
+    vcon.vcon_dict["attachments"].append({"body": "no key", "encoding": "none"})
+    vcon.add_attachment(body={"k": "v"}, type="findable")
+    assert vcon.find_attachment_by_purpose("findable") is not None
+    assert vcon.find_attachment_by_purpose("nonexistent") is None
 
 
 def test_find_analysis_by_type():


### PR DESCRIPTION
## Summary

IETF vCon spec 0.4.0 renamed the attachment `type` field to `purpose`. The python-vcon library (>=0.9.1) followed; attachments now arrive with only the `purpose` key. The Redis storage layer further normalizes `type → purpose` on save, so by the time a chain link reads a vCon back, attachments are consistently keyed under `purpose`.

`Vcon.find_attachment_by_type` still does `a["type"] == type`, which raises `KeyError` on spec-current attachments and crashes any chain link that uses it. The canonical victim is `conserver/links/tag/__init__.py` — its `add_tag(...)` transitively hits this lookup on every vCon, which is what testers have been reporting as the tag link failure.

## Changes

- **`common/vcon.py`**:
  - New `find_attachment_by_purpose(purpose)` — canonical method. Matches either `purpose` or `type`, using `.get(...)` so missing keys don't raise. Mirrors the dual-key tolerance the storage layer already does.
  - `find_attachment_by_type(type)` becomes a deprecated alias that delegates to the new method and emits `DeprecationWarning`. Keeps existing callers working through the migration.
  - Internal callers (`tags`, `get_tag`, `add_tag`) migrated to the new method.
- **`common/storage/elasticsearch/__init__.py`**: one internal caller migrated.
- **`common/tests/test_encoding.py`**: two test fixtures migrated.
- **`tests/core/test_vcon.py`**: existing `test_find_attachment_by_type` retained (proves the deprecated alias still works on legacy `type:` attachments, with `DeprecationWarning` suppressed). New tests:
  - `test_find_attachment_by_type_emits_deprecation_warning`
  - `test_find_attachment_by_purpose_matches_purpose_key`
  - `test_find_attachment_by_purpose_matches_legacy_type_key`
  - `test_find_attachment_by_purpose_tolerates_missing_keys`

## What's NOT in scope

Writers (`add_tag`, `add_attachment`) intentionally unchanged. The storage layer normalizes attachment keys to `purpose:` on persist, so the writer's in-memory output gets harmonized on the way to Redis. Flipping writer wire-format would risk confusing downstream consumers still mid-migration off `type:`. That belongs to a separate, ecosystem-coordinated change.

## Test plan

- [ ] `pytest tests/core/test_vcon.py` — all `test_find_attachment_*` tests pass
- [ ] `pytest common/tests/test_encoding.py` — passes (calls migrated to new method)
- [ ] On the test cluster, upload a BDS audio file via filebrowser → confirm the tag link no longer crashes and a tag attachment is present in the resulting vCon

🤖 Generated with [Claude Code](https://claude.com/claude-code)