### PR TITLE
feat(metrics): emit conserver.redis.memory_used_bytes observable gauge

### DIFF
--- a/common/lib/queue_metrics.py
+++ b/common/lib/queue_metrics.py
@@ -1,19 +1,18 @@
-"""Observable gauge emitting current ingress-list and DLQ depths.
+"""Observable gauges emitting Redis-derived conserver health metrics.
 
-The gauge ``conserver.ingress_list.length`` is sampled on every metric-export
-tick. Each observation carries:
+Two gauges are exported on every metric-export tick:
 
-  - ``ingress_list`` — the configured ingress list name as it appears in the
-    chain config (e.g. ``"transcribe"``)
-  - ``kind`` — ``"ingress"`` for the live queue, ``"dlq"`` for the derived
-    dead-letter queue
+  ``conserver.ingress_list.length`` — one observation per
+    ``(ingress_list, kind)`` combination, sampled via ``LLEN``. The
+    ``ingress_list`` attribute carries the configured name (e.g.
+    ``"transcribe"``); ``kind`` is ``"ingress"`` for the live queue and
+    ``"dlq"`` for the derived dead-letter queue. The ingress-list set is
+    re-read from configuration on every tick, so chain config changes
+    propagate without a conserver restart.
 
-Splitting ``kind`` into its own attribute (rather than baking ``DLQ:`` into
-the value) lets monitoring queries select live vs DLQ depth without regex
-parsing the metric label.
-
-The ingress-list set is re-read from configuration on every tick, so chain
-config changes propagate without a conserver restart.
+  ``conserver.redis.memory_used_bytes`` — current ``used_memory`` from
+    ``INFO memory``. Single series per pod (no per-key attributes); the
+    pod identity already lives on the resource attributes.
 """
 
 from opentelemetry.metrics import Observation
@@ -103,5 +102,56 @@ def register_ingress_list_length_gauge(client):
             "Current Redis LLEN for each configured ingress list and its "
             "derived DLQ. Attributes: ingress_list (configured name), "
             "kind (ingress|dlq)."
+        ),
+    )
+
+
+def _build_redis_memory_callback(client):
+    """Return a zero-arg callback that yields one Observation for
+    ``conserver.redis.memory_used_bytes`` per export tick.
+
+    Reads ``used_memory`` from ``INFO memory``. One round-trip per tick;
+    negligible cost. Returns an empty list on any failure so the export
+    tick still publishes everything else cleanly.
+    """
+
+    def _callback():
+        try:
+            info = client.info(section="memory")
+        except Exception as e:
+            logger.warning("Redis INFO memory failed: %s", e)
+            return []
+
+        used = info.get("used_memory") if isinstance(info, dict) else None
+        if used is None:
+            return []
+
+        try:
+            value = int(used)
+        except (TypeError, ValueError):
+            logger.warning("Redis INFO memory used_memory not int-coercible: %r", used)
+            return []
+
+        return [Observation(value=value, attributes={})]
+
+    return _callback
+
+
+def register_redis_memory_gauge(client):
+    """Register the ``conserver.redis.memory_used_bytes`` observable gauge.
+
+    Idempotent — safe to call multiple times per process. Restores the
+    Redis memory signal that monitoring stacks previously got from a
+    separately-deployed Redis exporter.
+
+    Args:
+        client: A Redis client with an ``info(section=...)`` method.
+    """
+    register_observable_gauge(
+        metric_name="conserver.redis.memory_used_bytes",
+        callback=_build_redis_memory_callback(client),
+        description=(
+            "Current Redis memory usage in bytes (used_memory from INFO memory). "
+            "One series per conserver pod."
         ),
     )

--- a/common/tests/test_queue_metrics.py
+++ b/common/tests/test_queue_metrics.py
@@ -1,14 +1,18 @@
-"""Unit tests for the ``conserver.ingress_list.length`` observable gauge.
+"""Unit tests for the observable gauges in ``lib.queue_metrics``.
 
-The callback construction can be tested without any OpenTelemetry SDK
-involvement — the helpers in ``lib.queue_metrics`` return a plain
-zero-arg callable whose output is a list of ``Observation``. This file
-exercises that callable directly.
+The callbacks are plain zero-arg callables returning a list of
+``Observation`` — they can be exercised without any OpenTelemetry SDK
+involvement. This file covers both the ingress-list-length callback and
+the Redis memory callback.
 """
 
 from unittest.mock import MagicMock, patch
 
-from lib.queue_metrics import _build_callback, _get_configured_ingress_lists
+from lib.queue_metrics import (
+    _build_callback,
+    _build_redis_memory_callback,
+    _get_configured_ingress_lists,
+)
 
 
 class TestConfiguredIngressLists:
@@ -150,3 +154,59 @@ class TestCallbackEmitsObservations:
             obs = cb()
         assert obs == []
         client.llen.assert_not_called()
+
+
+class TestRedisMemoryCallback:
+    def test_emits_single_observation_with_used_memory(self):
+        """Happy path: INFO memory returns a dict containing ``used_memory``;
+        the callback yields exactly one Observation with that integer value
+        and no attributes (host identity is on the resource, not per-series)."""
+        client = MagicMock()
+        client.info.return_value = {"used_memory": 12345678, "used_memory_peak": 20000000}
+        cb = _build_redis_memory_callback(client)
+
+        obs = cb()
+
+        assert len(obs) == 1
+        assert obs[0].value == 12345678
+        assert obs[0].attributes == {}
+        client.info.assert_called_once_with(section="memory")
+
+    def test_handles_info_failure(self):
+        """A Redis hiccup mid-export must NOT raise out of the callback
+        — degrade to no observation this tick."""
+        client = MagicMock()
+        client.info.side_effect = RuntimeError("connection lost")
+        cb = _build_redis_memory_callback(client)
+
+        assert cb() == []
+
+    def test_handles_missing_used_memory_key(self):
+        """Older Redis versions or unusual responses may omit
+        ``used_memory``. Skip the observation rather than crash."""
+        client = MagicMock()
+        client.info.return_value = {"used_memory_peak": 12345}
+        cb = _build_redis_memory_callback(client)
+
+        assert cb() == []
+
+    def test_handles_non_int_used_memory(self):
+        """If the value isn't int-coercible (shouldn't happen in practice
+        but the parser is paranoid), skip it."""
+        client = MagicMock()
+        client.info.return_value = {"used_memory": "not-a-number"}
+        cb = _build_redis_memory_callback(client)
+
+        assert cb() == []
+
+    def test_string_value_is_coerced_to_int(self):
+        """Some Redis clients return INFO values as strings; the callback
+        must coerce to int for the gauge type."""
+        client = MagicMock()
+        client.info.return_value = {"used_memory": "98765"}
+        cb = _build_redis_memory_callback(client)
+
+        obs = cb()
+        assert len(obs) == 1
+        assert obs[0].value == 98765
+        assert isinstance(obs[0].value, int)

--- a/conserver/main.py
+++ b/conserver/main.py
@@ -787,11 +787,13 @@ def worker_loop(worker_id: int) -> None:
     r = redis_mgr.get_client()
     queue = VconQueue(r)
 
-    # Register the ingress-list / DLQ depth gauge. The callback inside reads
-    # the live chain config on every tick, so new ingress lists begin
-    # emitting series automatically without a worker restart.
-    from lib.queue_metrics import register_ingress_list_length_gauge
+    # Register Redis-derived gauges. ingress_list.length samples LLEN per
+    # configured ingress + DLQ; redis.memory_used_bytes samples INFO memory.
+    # The ingress callback re-reads chain config on every tick, so new ingress
+    # lists begin emitting series automatically without a worker restart.
+    from lib.queue_metrics import register_ingress_list_length_gauge, register_redis_memory_gauge
     register_ingress_list_length_gauge(r)
+    register_redis_memory_gauge(r)
 
     # Re-register signal handler in worker process
     signal.signal(signal.SIGTERM, signal_handler)


### PR DESCRIPTION
## Summary

Adds a second observable gauge in `common/lib/queue_metrics.py`:

| Metric | Source | Attributes |
|---|---|---|
| `conserver.redis.memory_used_bytes` | `INFO memory` → `used_memory` | none (pod identity is on resource) |

Sampled on every metric-export tick alongside `conserver.ingress_list.length`. One round-trip per pod per tick; negligible cost.

The metric exists so monitoring stacks can observe Redis memory pressure directly from the conserver process — useful when a deployment doesn't run a separate Redis exporter.

## Test plan

- [x] New tests in `common/tests/test_queue_metrics.py`:
  - happy path: one Observation with the correct integer value, no attributes
  - `INFO memory` failure → no observation, no exception
  - missing `used_memory` key → no observation
  - non-int `used_memory` (defensive) → no observation
  - string `used_memory` (some clients) → coerced to int

  All 13 tests in the module pass.
- [ ] Manual verification on a running deployment: roll the new image, confirm `conserver.redis.memory_used_bytes` shows up in the metrics backend with one series per pod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)