### PR TITLE
fix(metrics): drop vcon.uuid from conserver.link.execution_time histogram

### DIFF
--- a/conserver/main.py
+++ b/conserver/main.py
@@ -604,12 +604,17 @@ class VconChainRequest:
                     self.vcon_id, link_name, module, options, link_hook_config, "success", None, parties
                 )
                 link_processing_time = round(time.time() - started, 3)
+                # NB: do NOT include vcon.uuid here. This is a Histogram metric
+                # — every unique attribute combination produces its own
+                # OpenTelemetry time-series, so per-vCon labels would create
+                # unbounded cardinality and break percentile aggregation across
+                # vCons. Trace-level vcon.uuid lives on the span (see the
+                # vcon_processing.<chain_name> span this block runs inside).
                 record_histogram(
                     "conserver.link.execution_time",
                     link_processing_time,
                     attributes={
                         "link.name": link_name,
-                        "vcon.uuid": self.vcon_id,
                         "chain.name": self.chain_details["name"],
                     },
                 )


### PR DESCRIPTION
## Summary

\`conserver.link.execution_time\` is a histogram with attributes \`link.name\`, \`vcon.uuid\`, \`chain.name\`. OpenTelemetry emits one time-series per unique attribute combination, so the per-vCon \`vcon.uuid\` label means **one histogram series per processed vCon** — unbounded cardinality, with at most one data point per series. Querying percentiles across vCons returns no usable result; the metric is effectively per-event noise.

Removing \`vcon.uuid\` from the attribute dict collapses the cardinality back to the intended \`link.name × chain.name\` shape (a handful of series), and percentiles work as designed.

The trace-level \`vcon.uuid\` already lives on the \`vcon_processing.<chain_name>\` span the block runs inside, so per-request identity is still queryable via traces — just not via the histogram label.

## Test plan

- [x] No test asserts on \`conserver.link.execution_time\` attributes (grep confirmed; \`test_link_metrics.py\` only tests per-link metrics like \`conserver.link.deepgram.transcription_time\`).
- [x] Existing tests pass (\`test_queue_metrics.py\`, \`test_queue_dlq_counter.py\`, \`test_dlq_expiry.py\`, \`test_parallel_processing.py\` — 33 pass).
- [ ] After deploy: histogram in the metrics backend collapses from N series (per vCon) to a small constant set, and p95 queries grouped by \`link.name\` return real percentiles.

## Caveats

Per-link metrics emitted from individual link modules (e.g. \`conserver.link.deepgram.transcription_time\`, \`conserver.link.scitt.*\`) still include \`vcon.uuid\` in their attributes and have the same cardinality issue. They're not touched here because:
1. Tests in \`test_link_metrics.py\` explicitly assert on the current shape — fixing them needs test updates too
2. Those metrics are emitted at lower volumes than the main loop's histogram, so the blast radius is smaller

Worth a follow-up PR that updates both the link modules and the tests in one pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)