### PR TITLE
test: fix CI failures from spec-canonical body shape

### DIFF
--- a/common/tests/test_encoding.py
+++ b/common/tests/test_encoding.py
@@ -10,18 +10,45 @@ def test_encoding():
     print("test_vcon:", _vcon)
     test_vcon = vcon.Vcon(_vcon)
 
+    # Spec (draft-ietf-vcon-vcon-core-02 §2.3.2): body is always a String. A
+    # dict/list passed in for convenience is JSON-encoded at the boundary and
+    # the encoding is forced to "json".
+    test_vcon.add_attachment(
+        type="test_encoding_dict_coerced",
+        body={"key": "value"},
+        encoding="json",
+    )
+    assert test_vcon.find_attachment_by_purpose("test_encoding_dict_coerced") == {
+        "type": "test_encoding_dict_coerced",
+        "body": json.dumps({"key": "value"}),
+        "encoding": "json",
+    }
+
+    test_vcon.add_attachment(
+        type="test_encoding_list_coerced",
+        body=["key", "value"],
+        encoding="base64url",
+    )
+    assert test_vcon.find_attachment_by_purpose("test_encoding_list_coerced") == {
+        "type": "test_encoding_list_coerced",
+        "body": json.dumps(["key", "value"]),
+        "encoding": "json",
+    }
+
+    # Invalid JSON string with encoding=json still raises.
     with pytest.raises(Exception):
         test_vcon.add_attachment(
-            type="test_encoding",
-            body={"key": "value"},
+            type="test_encoding_bad_json",
+            body="not-valid-json",
             encoding="json",
         )
 
+    # Invalid base64url string with encoding=base64url still raises.
     with pytest.raises(Exception):
         test_vcon.add_attachment(
-                type= "test_encoding",
-                body=["key", "value"],
-                encoding= "base64url",
+            type="test_encoding_bad_b64",
+            body="not valid base64!!!",
+            encoding="base64url",
         )
 
     test_vcon.add_attachment(

--- a/conserver/links/groq_whisper/test_groq_whisper.py
+++ b/conserver/links/groq_whisper/test_groq_whisper.py
@@ -435,7 +435,9 @@ def test_get_transcription(sample_vcon_with_existing_transcript):
     assert transcript is not None
     assert transcript["type"] == "transcript"
     assert transcript["dialog"] == 0
-    assert transcript["body"]["text"] == "Existing transcript"
+    # add_analysis JSON-encodes a dict body at the boundary per spec
+    # (draft-ietf-vcon-vcon-core-02 §2.3.2), so decode before drilling in.
+    assert Vcon.decoded_body(transcript)["text"] == "Existing transcript"
     
     # Check non-existent transcription
     transcript = get_transcription(sample_vcon_with_existing_transcript, 1)  # No dialog at index 1

--- a/conserver/tests/test_link_metrics.py
+++ b/conserver/tests/test_link_metrics.py
@@ -431,6 +431,7 @@ class TestCheckAndTagMetrics:
     def test_tag_applied_increments_counter(self, metric_reader):
         vcon = make_transcript_vcon()
         vcon.analysis[0]["body"] = "Hello world"
+        vcon.analysis[0]["encoding"] = "none"
         self._run(vcon, applies=True)
         metrics = extract_metrics(metric_reader)
         assert_metric_has_attrs(metrics, "conserver.link.openai.tags_applied",
@@ -441,6 +442,7 @@ class TestCheckAndTagMetrics:
     def test_success_records_evaluation_time(self, metric_reader):
         vcon = make_transcript_vcon()
         vcon.analysis[0]["body"] = "Hello world"
+        vcon.analysis[0]["encoding"] = "none"
         self._run(vcon, applies=True)
         metrics = extract_metrics(metric_reader)
         assert_metric_has_attrs(metrics, "conserver.link.openai.evaluation_time",
@@ -450,6 +452,7 @@ class TestCheckAndTagMetrics:
     def test_failure_increments_counter(self, metric_reader):
         vcon = make_transcript_vcon()
         vcon.analysis[0]["body"] = "Hello world"
+        vcon.analysis[0]["encoding"] = "none"
         self._run(vcon, side_effect=Exception("OpenAI error"))
         metrics = extract_metrics(metric_reader)
         assert_metric_has_attrs(metrics, "conserver.link.openai.evaluation_failures",


### PR DESCRIPTION
## Summary
Fixes the 5 unit-test failures introduced by PR #182 (`fix(vcon): decode body per spec on read, canonicalize on write`):

- `common/tests/test_encoding.py::test_encoding` — old test asserted dict/list bodies raise; new `add_attachment` intentionally coerces them to `encoding=json` + JSON-stringified body. Rewrote assertions to match, kept raises for genuinely invalid input.
- `conserver/links/groq_whisper/test_groq_whisper.py::test_get_transcription` — `transcript["body"]["text"]` blew up because body is now a JSON string; switched to `Vcon.decoded_body(transcript)["text"]`.
- `conserver/tests/test_link_metrics.py::TestCheckAndTagMetrics::*` (3 tests) — overriding `analysis[0]["body"]` to a plain string left `encoding="json"` (set by `add_analysis` when the fixture's dict body was canonicalized). `Vcon.with_decoded_body()` then raised on `json.loads("Hello world")`, swallowed silently, no metric recorded. Added `analysis[0]["encoding"] = "none"` alongside each body override.

Test-only change; no production code touched.

## Test plan
- [x] `pytest common/tests/test_encoding.py conserver/links/groq_whisper/test_groq_whisper.py::test_get_transcription conserver/tests/test_link_metrics.py::TestCheckAndTagMetrics` → 5 passed
- [x] Full suite runs to completion (610 passed; 2 pre-existing `test_api` flakes unrelated to this change)