### PR TITLE
investigate(vcon): log caller stack + coerce str arg in Vcon.__init__

### DIFF
--- a/common/vcon.py
+++ b/common/vcon.py
@@ -1,5 +1,6 @@
 import copy
 import json
+import logging
 import warnings
 from typing import Optional, Union
 import hashlib
@@ -13,9 +14,32 @@ import os
 _LAST_V8_TIMESTAMP = None
 UUID8_DOMAIN_NAME = os.getenv("UUID8_DOMAIN_NAME", "strolid.com")
 
+_logger = logging.getLogger(__name__)
+
 
 class Vcon:
     def __init__(self, vcon_dict={}):
+        # Defensive: production logs show callers occasionally pass a
+        # JSON-encoded string here, which silently round-trips through
+        # json.dumps/loads and leaves self.vcon_dict as a str. Every
+        # downstream access (e.g. find_attachment_by_purpose at line
+        # ``self.vcon_dict["attachments"]``) then crashes with
+        # ``TypeError: string indices must be integers, not 'str'``.
+        # Coerce the string back to a dict and log the caller stack so
+        # we can find and fix the originating call site.
+        if isinstance(vcon_dict, str):
+            _logger.error(
+                "Vcon.__init__ received a str (len=%d, head=%r); coercing via json.loads",
+                len(vcon_dict),
+                vcon_dict[:200],
+                stack_info=True,
+            )
+            try:
+                vcon_dict = json.loads(vcon_dict)
+            except json.JSONDecodeError:
+                # Not JSON either — bail out with an empty dict rather
+                # than poisoning self.vcon_dict for downstream callers.
+                vcon_dict = {}
         # deep copy
         self.vcon_dict = json.loads(json.dumps(vcon_dict))
 

--- a/tests/core/test_vcon.py
+++ b/tests/core/test_vcon.py
@@ -122,6 +122,35 @@ def test_find_attachment_by_type_emits_deprecation_warning():
         vcon.find_attachment_by_type("x")
 
 
+def test_init_coerces_json_string_arg_and_logs_caller(caplog):
+    # Production logs show callers occasionally pass a JSON-encoded string
+    # instead of a dict. Pre-fix, json.loads(json.dumps(str)) silently
+    # round-trips and leaves vcon_dict as a str — every downstream method
+    # then crashes with TypeError: string indices must be integers.
+    # Post-fix, __init__ must coerce the string back to a dict and emit
+    # an ERROR log with a caller stack so the originating call site is
+    # findable.
+    payload = '{"uuid": "abc", "vcon": "0.0.1", "attachments": [{"purpose": "tags", "body": "[]", "encoding": "json"}], "parties": [], "dialog": [], "analysis": [], "group": [], "redacted": {}}'
+    with caplog.at_level("ERROR", logger="vcon"):
+        v = Vcon(payload)
+    assert isinstance(v.vcon_dict, dict)
+    assert v.vcon_dict["uuid"] == "abc"
+    # add_tag would otherwise raise TypeError here pre-fix
+    v.add_tag("k", "v")
+    assert any("received a str" in rec.message for rec in caplog.records)
+    assert any(rec.stack_info for rec in caplog.records if "received a str" in rec.message)
+
+
+def test_init_bails_to_empty_dict_for_non_json_string(caplog):
+    # If the bad input is not even valid JSON, fall through to an empty
+    # vcon_dict rather than leaving a poisoned string. Caller stack must
+    # still be logged so the broken caller is findable.
+    with caplog.at_level("ERROR", logger="vcon"):
+        v = Vcon("not even json")
+    assert v.vcon_dict == {}
+    assert any("received a str" in rec.message for rec in caplog.records)
+
+
 def test_find_attachment_by_purpose_matches_purpose_key():
     # IETF vCon spec 0.4.0 renamed `type` → `purpose` on attachments. The
     # canonical lookup must find attachments authored by spec-current writers.

--- a/tests/core/test_vcon.py
+++ b/tests/core/test_vcon.py
@@ -122,7 +122,27 @@ def test_find_attachment_by_type_emits_deprecation_warning():
         vcon.find_attachment_by_type("x")
 
 
-def test_init_coerces_json_string_arg_and_logs_caller(caplog):
+@pytest.fixture
+def vcon_logger_propagates():
+    # ``common/logging.conf`` sets ``[logger_vcon] propagate = 0`` so log
+    # records go straight to the project's JSON stdout handler and bypass
+    # the root logger that ``caplog`` attaches to. Force propagation for
+    # the duration of the test so ``caplog.records`` actually sees the
+    # records, then restore the original setting.
+    import logging
+    logger = logging.getLogger("vcon")
+    saved_propagate = logger.propagate
+    saved_disabled = logger.disabled
+    logger.propagate = True
+    logger.disabled = False
+    try:
+        yield logger
+    finally:
+        logger.propagate = saved_propagate
+        logger.disabled = saved_disabled
+
+
+def test_init_coerces_json_string_arg_and_logs_caller(caplog, vcon_logger_propagates):
     # Production logs show callers occasionally pass a JSON-encoded string
     # instead of a dict. Pre-fix, json.loads(json.dumps(str)) silently
     # round-trips and leaves vcon_dict as a str — every downstream method
@@ -141,7 +161,7 @@ def test_init_coerces_json_string_arg_and_logs_caller(caplog):
     assert any(rec.stack_info for rec in caplog.records if "received a str" in rec.message)
 
 
-def test_init_bails_to_empty_dict_for_non_json_string(caplog):
+def test_init_bails_to_empty_dict_for_non_json_string(caplog, vcon_logger_propagates):
     # If the bad input is not even valid JSON, fall through to an empty
     # vcon_dict rather than leaving a poisoned string. Caller stack must
     # still be logged so the broken caller is findable.


### PR DESCRIPTION
## Why

A production conserver has been emitting a continuous stream of `conserver.link.count{link_name=tag, outcome=error}` with the same exception:

```
TypeError: string indices must be integers, not 'str'
  File "conserver/links/tag/__init__.py", in run
    vCon.add_tag(tag_name=tag, tag_value=tag)
  File "common/vcon.py", in add_tag
    tags_attachment = self.find_attachment_by_purpose("tags")
  File "common/vcon.py", in find_attachment_by_purpose
    for a in self.vcon_dict["attachments"]
             ~~~~~~~~~~~~~~^^^^^^^^^^^^^^^
TypeError: string indices must be integers, not 'str'
```

`self.vcon_dict` is a **`str`** at failure time. But:

- Every sampled vCon in Redis (`JSON.TYPE`) is `object`, with `.attachments` an `array`.
- Local repro with the same dict shape succeeds.
- The deployed code is current with #182 and #184.

So a caller is reaching `Vcon.__init__` with a JSON-encoded **string** instead of the parsed dict. The current `__init__` (`self.vcon_dict = json.loads(json.dumps(vcon_dict))`) silently round-trips a `str`, leaving `self.vcon_dict` as a `str`. The crash only surfaces on the first dict-style access — typically `find_attachment_by_purpose` from the tag link.

Static analysis didn't find the bad caller. This PR adds the instrumentation that will.

## What this change does

1. Detect `isinstance(vcon_dict, str)` at the `Vcon.__init__` boundary and log an `ERROR` with `stack_info=True`. The next failure to land will show the originating call site.
2. Coerce valid JSON-strings back to a dict so the chain doesn't crash and vCons don't pile up in the DLQ during the investigation. Non-JSON input falls back to `{}` rather than poisoning downstream access.

The defensive coercion is meant to live only as long as it takes to identify the caller and fix it at source.

## Test plan

- [x] `pytest tests/core/test_vcon.py` — 36/36 pass, including two new regression tests:
  - `test_init_coerces_json_string_arg_and_logs_caller`
  - `test_init_bails_to_empty_dict_for_non_json_string`
- [ ] Deploy and grep logs for `Vcon.__init__ received a str` lines + their stack — should identify the bad caller within minutes.
- [ ] Verify `conserver.link.count{link_name=tag, outcome=error}` rate drops to ~0 after deploy (defensive coercion takes over).

🤖 Generated with [Claude Code](https://claude.com/claude-code)