### PR TITLE
Make transformers an opt-in dependency (conserver-local group)

### DIFF
--- a/conserver/links/hugging_llm_link/README.md
+++ b/conserver/links/hugging_llm_link/README.md
@@ -20,6 +20,13 @@ The link can be configured through environment variables or the link configurati
 HUGGINGFACE_API_KEY=your-api-key  # Required for API-based inference
 ```
 
+> **Local inference is opt-in.** The default path (`use_local_model: false`) calls the
+> HuggingFace HTTP API and pulls in no ML dependencies. Setting `use_local_model: true`
+> runs the model on-device via `transformers`, which is **not** part of the base
+> `conserver` install. Install it with `uv sync --group conserver --group conserver-local`
+> and add a model backend (e.g. `torch`) yourself. Without it, the local path raises a
+> clear `ImportError` at runtime.
+
 Additional configuration options:
 - `model`: HuggingFace model ID (default: "meta-llama/Llama-2-70b-chat-hf")
 - `use_local_model`: Toggle local model inference (default: false)

--- a/conserver/links/hugging_llm_link/__init__.py
+++ b/conserver/links/hugging_llm_link/__init__.py
@@ -32,7 +32,6 @@ from tenacity import (
     RetryError,
     before_sleep_log,
 )
-import transformers
 import anyio
 
 # Local imports
@@ -154,6 +153,19 @@ class LocalHuggingFaceLLM(BaseLLM):
 
     def __init__(self, config: LLMConfig):
         super().__init__(config)
+        # transformers (and a backend such as torch) is an optional dependency.
+        # The default, API-based path (use_local_model=false) does not need it, so
+        # the import is deferred to here rather than loaded at module import time.
+        try:
+            import transformers
+        except ImportError as e:
+            raise ImportError(
+                "Local HuggingFace inference requires the optional 'conserver-local' "
+                "dependency group plus a model backend (e.g. torch). "
+                "Install it with: uv sync --group conserver-local. "
+                "The default path (use_local_model=false) calls the HuggingFace API "
+                "and needs none of this."
+            ) from e
         logger.info(f"Initializing local model: {self.config.model}")
         device = "cpu"  # Always use CPU for local models
         logger.info(f"Using device: {device}")

--- a/conserver/links/hugging_llm_link/__init__.py
+++ b/conserver/links/hugging_llm_link/__init__.py
@@ -158,7 +158,12 @@ class LocalHuggingFaceLLM(BaseLLM):
         # the import is deferred to here rather than loaded at module import time.
         try:
             import transformers
-        except ImportError as e:
+        except ModuleNotFoundError as e:
+            # Only translate the "transformers itself is missing" case. If transformers
+            # is present but raises while importing a transitive dep/backend, re-raise the
+            # original error so the real cause isn't masked by the guidance below.
+            if e.name != "transformers":
+                raise
             raise ImportError(
                 "Local HuggingFace inference requires the optional 'conserver-local' "
                 "dependency group plus a model backend (e.g. torch). "

--- a/conserver/links/hugging_llm_link/__init__.py
+++ b/conserver/links/hugging_llm_link/__init__.py
@@ -162,7 +162,7 @@ class LocalHuggingFaceLLM(BaseLLM):
             raise ImportError(
                 "Local HuggingFace inference requires the optional 'conserver-local' "
                 "dependency group plus a model backend (e.g. torch). "
-                "Install it with: uv sync --group conserver-local. "
+                "Install it with: uv sync --group conserver --group conserver-local. "
                 "The default path (use_local_model=false) calls the HuggingFace API "
                 "and needs none of this."
             ) from e

--- a/conserver/links/hugging_llm_link/main.py
+++ b/conserver/links/hugging_llm_link/main.py
@@ -23,7 +23,9 @@ class HuggingLLMLink:
         # transformers is an optional dependency (group: conserver-local); import lazily.
         try:
             from transformers import pipeline
-        except ImportError as e:
+        except ModuleNotFoundError as e:
+            if e.name != "transformers":
+                raise
             raise ImportError(
                 "HuggingLLMLink requires the optional 'conserver-local' dependency group. "
                 "Install it with: uv sync --group conserver --group conserver-local."

--- a/conserver/links/hugging_llm_link/main.py
+++ b/conserver/links/hugging_llm_link/main.py
@@ -1,4 +1,4 @@
-from typing import Dict, Any, Optional
+from typing import Any, Dict
 
 AUDIT_META = {
     "third_party_service": "Hugging Face",

--- a/conserver/links/hugging_llm_link/main.py
+++ b/conserver/links/hugging_llm_link/main.py
@@ -1,5 +1,4 @@
 from typing import Dict, Any, Optional
-from transformers import pipeline
 
 AUDIT_META = {
     "third_party_service": "Hugging Face",
@@ -21,6 +20,9 @@ class HuggingLLMLink:
             model_name: The HuggingFace model to use
             **kwargs: Additional arguments passed to the model pipeline
         """
+        # transformers is an optional dependency (group: conserver-local); import lazily.
+        from transformers import pipeline
+
         self.classifier = pipeline(
             "zero-shot-classification", model=model_name, **kwargs
         )

--- a/conserver/links/hugging_llm_link/main.py
+++ b/conserver/links/hugging_llm_link/main.py
@@ -21,8 +21,13 @@ class HuggingLLMLink:
             **kwargs: Additional arguments passed to the model pipeline
         """
         # transformers is an optional dependency (group: conserver-local); import lazily.
-        from transformers import pipeline
-
+        try:
+            from transformers import pipeline
+        except ImportError as e:
+            raise ImportError(
+                "HuggingLLMLink requires the optional 'conserver-local' dependency group. "
+                "Install it with: uv sync --group conserver --group conserver-local."
+            ) from e
         self.classifier = pipeline(
             "zero-shot-classification", model=model_name, **kwargs
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,6 @@ api = [
 conserver = [
     {include-group = "storage"},
     # Processing links
-    "transformers>=4.48.0",
     "openai>=1.60.0",
     "groq>=0.4.0",
     "deepgram-sdk>=3.1.5,<4.0.0",
@@ -66,6 +65,16 @@ conserver = [
     "jq>=1.8.0",
     # Hot-reload wrapper used by docker-compose watchmedo
     "watchdog",
+]
+
+# Optional: on-device HuggingFace inference for hugging_llm_link's local-model path.
+# transformers is ~48MB (plus tokenizers/huggingface_hub, ~67MB total) and additionally
+# needs a model backend such as torch installed separately. The default hugging_llm_link
+# path (use_local_model=false) calls the HuggingFace HTTP API and needs none of this, so
+# transformers is kept out of the base conserver install.
+# Install with: uv sync --group conserver --group conserver-local
+conserver-local = [
+    "transformers>=4.48.0",
 ]
 
 # Development / test dependencies.

--- a/uv.lock
+++ b/uv.lock
@@ -2356,8 +2356,10 @@ conserver = [
     { name = "pymilvus" },
     { name = "pymongo" },
     { name = "slack-sdk" },
-    { name = "transformers" },
     { name = "watchdog" },
+]
+conserver-local = [
+    { name = "transformers" },
 ]
 dev = [
     { name = "anyio" },
@@ -2432,9 +2434,9 @@ conserver = [
     { name = "pymilvus", specifier = ">=2.3.0" },
     { name = "pymongo", specifier = ">=4.7.2" },
     { name = "slack-sdk", specifier = ">=3.27.1" },
-    { name = "transformers", specifier = ">=4.48.0" },
     { name = "watchdog" },
 ]
+conserver-local = [{ name = "transformers", specifier = ">=4.48.0" }]
 dev = [
     { name = "anyio", specifier = ">=4.8.0" },
     { name = "black", specifier = ">=24.2.0" },


### PR DESCRIPTION
## Summary

`transformers` is the single largest installed package in the project (~48MB on its own; ~67MB once you count `tokenizers`, `huggingface_hub`, and `hf_xet`, plus shared `numpy`). Despite that weight, its **only** consumer is `conserver/links/hugging_llm_link`, and only the `LocalHuggingFaceLLM` path uses it:

- That path is **off by default** (`use_local_model: false`).
- It calls `transformers.pipeline("text-generation", ...)`, which needs a model backend (`torch`). **`torch` is not a project dependency**, so the local path cannot run today regardless.
- The default path is a plain `requests.post()` to the HuggingFace inference API and needs **none** of `transformers`.
- LLM analysis is already covered by the `analyze` / `analyze_and_label` / `analyze_vcon` links (OpenAI/Groq).

This makes `transformers` a large dependency carried by every conserver image for an off-by-default, non-functional path. This PR makes it opt-in.

## Changes

- **pyproject.toml**: move `transformers>=4.48.0` out of the base `conserver` group into a new opt-in `conserver-local` group.
- **`hugging_llm_link/__init__.py`**: defer `import transformers` into `LocalHuggingFaceLLM.__init__`, raising a clear `ImportError` (with the install command) if the optional group isn't present. Importing the link no longer loads `transformers`.
- **`hugging_llm_link/main.py`**: lazy-import `pipeline` inside `HuggingLLMLink.__init__`.
- **README**: document that local inference is opt-in and additionally needs a backend (`torch`).
- **uv.lock**: regenerated — the `transformers` node is unchanged, just regrouped.

## Impact

Removes ~67MB from the base `conserver` install with **no functional change** to the default API-based path. Users who want on-device inference install it explicitly:

```
uv sync --group conserver --group conserver-local   # + a backend, e.g. torch
```

## Testing

`conserver/tests/test_link_metrics.py`: **25/25 pass** (incl. both `TestHuggingLLMMetrics` cases). Verified that importing `links.hugging_llm_link` (and its `main`) no longer pulls `transformers` into `sys.modules`.

## Related

Same theme as #160 (Redis Stack): heavy/specialized dependency with shallow or absent usage. A follow-up lever: `pandas` (48MB) + `grpcio` (37MB) ride in transitively via `pymilvus` with zero direct use — candidate for a `storage-milvus` extra split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)