### PR TITLE
Make Milvus storage backend opt-in (storage-milvus group)

### DIFF
--- a/common/storage/milvus/README.md
+++ b/common/storage/milvus/README.md
@@ -2,6 +2,12 @@
 
 This module implements vector database storage using Milvus for the vCon server.
 
+> **Optional dependency.** `pymilvus` (which pulls in pandas + grpcio, ~85MB the
+> rest of vcon-server does not use) is **not** part of the base `storage` group.
+> Install it explicitly to use this backend:
+> `uv sync --group storage --group storage-milvus`. Without it, loading
+> `storage.milvus` raises a clear `ImportError`.
+
 ## Overview
 
 Milvus storage provides high-performance vector similarity search capabilities, ideal for storing and retrieving vector embeddings of vCon data. It's particularly useful for semantic search and similarity matching applications.

--- a/common/storage/milvus/README.md
+++ b/common/storage/milvus/README.md
@@ -6,7 +6,7 @@ This module implements vector database storage using Milvus for the vCon server.
 > rest of vcon-server does not use) is **not** part of the base `storage` group.
 > Install it explicitly to use this backend:
 > `uv sync --group storage --group storage-milvus`. Without it, importing
-> `storage.milvus` raises `ImportError`/`ModuleNotFoundError`.
+> `storage.milvus` will fail with `ImportError`/`ModuleNotFoundError` due to the missing dependency.
 
 ## Overview
 

--- a/common/storage/milvus/README.md
+++ b/common/storage/milvus/README.md
@@ -5,8 +5,8 @@ This module implements vector database storage using Milvus for the vCon server.
 > **Optional dependency.** `pymilvus` (which pulls in pandas + grpcio, ~85MB the
 > rest of vcon-server does not use) is **not** part of the base `storage` group.
 > Install it explicitly to use this backend:
-> `uv sync --group storage --group storage-milvus`. Without it, loading
-> `storage.milvus` raises a clear `ImportError`.
+> `uv sync --group storage --group storage-milvus`. Without it, importing
+> `storage.milvus` raises `ImportError`/`ModuleNotFoundError`.
 
 ## Overview
 

--- a/common/storage/milvus/test_milvus.py
+++ b/common/storage/milvus/test_milvus.py
@@ -1,9 +1,10 @@
 import pytest
 from unittest.mock import patch, MagicMock, mock_open
 
-# pymilvus is an optional dependency (group: storage-milvus). storage.milvus
-# imports it at module load, so skip this whole module when it isn't installed.
+# pymilvus/openai are optional dependencies (group: storage-milvus). storage.milvus
+# imports them at module load, so skip this whole module when they aren't installed.
 pytest.importorskip("pymilvus")
+pytest.importorskip("openai")
 
 from lib.vcon_redis import VconRedis
 from vcon import Vcon

--- a/common/storage/milvus/test_milvus.py
+++ b/common/storage/milvus/test_milvus.py
@@ -1,6 +1,10 @@
 import pytest
 from unittest.mock import patch, MagicMock, mock_open
 
+# pymilvus is an optional dependency (group: storage-milvus). storage.milvus
+# imports it at module load, so skip this whole module when it isn't installed.
+pytest.importorskip("pymilvus")
+
 from lib.vcon_redis import VconRedis
 from vcon import Vcon
 from storage.milvus import (

--- a/common/storage/milvus/test_milvus_branches.py
+++ b/common/storage/milvus/test_milvus_branches.py
@@ -2,6 +2,10 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+# pymilvus is an optional dependency (group: storage-milvus). storage.milvus
+# imports it at module load, so skip this whole module when it isn't installed.
+pytest.importorskip("pymilvus")
+
 from storage import milvus as milvus_module
 from storage.milvus import (
     check_vcon_exists,

--- a/common/storage/milvus/test_milvus_branches.py
+++ b/common/storage/milvus/test_milvus_branches.py
@@ -2,9 +2,10 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-# pymilvus is an optional dependency (group: storage-milvus). storage.milvus
-# imports it at module load, so skip this whole module when it isn't installed.
+# pymilvus/openai are optional dependencies (group: storage-milvus). storage.milvus
+# imports them at module load, so skip this whole module when they aren't installed.
 pytest.importorskip("pymilvus")
+pytest.importorskip("openai")
 
 from storage import milvus as milvus_module
 from storage.milvus import (

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -29,9 +29,11 @@ COPY pyproject.toml uv.lock /app/
 
 # Install all groups (conserver + api + dev) so the image works for both
 # running services and running pytest.
+# storage-milvus is included here (but NOT in the production Dockerfile.conserver /
+# Dockerfile.api images) so the Milvus storage tests run in CI rather than skip.
 # Venv at /opt/venv so docker-compose volume mounts don't wipe it.
 RUN uv venv --seed /opt/venv && \
-    UV_PROJECT_ENVIRONMENT=/opt/venv uv sync --frozen --group conserver --group api --group dev
+    UV_PROJECT_ENVIRONMENT=/opt/venv uv sync --frozen --group conserver --group api --group dev --group storage-milvus
 ENV PATH="/opt/venv/bin:$PATH"
 
 # Auto-install OTel instrumentation packages for the installed libraries.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,11 +34,21 @@ dependencies = [
 storage = [
     "pymongo>=4.7.2",
     "elasticsearch>=8.13.1,<9.0.0",
-    "pymilvus>=2.3.0",
     "msal>=1.32.3",
     "boto3>=1.34.52",
     "psycopg2-binary>=2.9.9",
     "peewee>=3.17.1",
+]
+
+# Optional: Milvus vector-database storage backend (storage.milvus).
+# pymilvus drags in pandas (~48MB) and grpcio (~37MB), neither of which the
+# rest of vcon-server uses, so it is kept out of the base `storage` group.
+# Includes openai for the embedding calls the backend makes. Only installs
+# pymilvus when explicitly requested; storage.milvus raises a clear ImportError
+# otherwise. Install with: uv sync --group storage --group storage-milvus
+storage-milvus = [
+    "pymilvus>=2.3.0",
+    "openai>=1.60.0",
 ]
 
 # API service dependencies — HTTP layer and API key management.

--- a/uv.lock
+++ b/uv.lock
@@ -2336,7 +2336,6 @@ api = [
     { name = "msal" },
     { name = "peewee" },
     { name = "psycopg2-binary" },
-    { name = "pymilvus" },
     { name = "pymongo" },
     { name = "starlette" },
     { name = "uvicorn" },
@@ -2353,7 +2352,6 @@ conserver = [
     { name = "peewee" },
     { name = "psycopg2-binary" },
     { name = "pydub" },
-    { name = "pymilvus" },
     { name = "pymongo" },
     { name = "slack-sdk" },
     { name = "transformers" },
@@ -2377,8 +2375,11 @@ storage = [
     { name = "msal" },
     { name = "peewee" },
     { name = "psycopg2-binary" },
-    { name = "pymilvus" },
     { name = "pymongo" },
+]
+storage-milvus = [
+    { name = "openai" },
+    { name = "pymilvus" },
 ]
 
 [package.metadata]
@@ -2412,7 +2413,6 @@ api = [
     { name = "msal", specifier = ">=1.32.3" },
     { name = "peewee", specifier = ">=3.17.1" },
     { name = "psycopg2-binary", specifier = ">=2.9.9" },
-    { name = "pymilvus", specifier = ">=2.3.0" },
     { name = "pymongo", specifier = ">=4.7.2" },
     { name = "starlette", specifier = ">=0.40.0" },
     { name = "uvicorn", specifier = "==0.23.2" },
@@ -2429,7 +2429,6 @@ conserver = [
     { name = "peewee", specifier = ">=3.17.1" },
     { name = "psycopg2-binary", specifier = ">=2.9.9" },
     { name = "pydub", specifier = ">=0.25.1" },
-    { name = "pymilvus", specifier = ">=2.3.0" },
     { name = "pymongo", specifier = ">=4.7.2" },
     { name = "slack-sdk", specifier = ">=3.27.1" },
     { name = "transformers", specifier = ">=4.48.0" },
@@ -2453,8 +2452,11 @@ storage = [
     { name = "msal", specifier = ">=1.32.3" },
     { name = "peewee", specifier = ">=3.17.1" },
     { name = "psycopg2-binary", specifier = ">=2.9.9" },
-    { name = "pymilvus", specifier = ">=2.3.0" },
     { name = "pymongo", specifier = ">=4.7.2" },
+]
+storage-milvus = [
+    { name = "openai", specifier = ">=1.60.0" },
+    { name = "pymilvus", specifier = ">=2.3.0" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

`pymilvus` is the **only** consumer of `pandas` (~48MB) and `grpcio` (~37MB) in the project, yet neither is used directly anywhere in vcon-server. Milvus is just one of ~14 storage backends, and backends are loaded lazily via `importlib.import_module` only when a storage with that module is configured ([common/storage/base.py](../blob/main/common/storage/base.py)). So `pymilvus` (and its heavy transitive deps) doesn't belong in the base install — this PR makes it opt-in.

Same theme as the `transformers` change (#188) and #160: a heavy, specialized dependency carried by every image despite shallow/optional use.

## Changes

- **pyproject.toml**: move `pymilvus>=2.3.0` out of the base `storage` group into a new opt-in `storage-milvus` group (which also includes `openai`, used by the backend for embeddings).
- **test_milvus.py / test_milvus_branches.py**: add `pytest.importorskip("pymilvus")` so both modules skip cleanly when the optional dep isn't installed (both import `storage.milvus`, which imports `pymilvus` at module load).
- **docker/Dockerfile** (dev/test image only): add `--group storage-milvus` so Milvus tests still **run** in CI. The production `Dockerfile.conserver` / `Dockerfile.api` images are untouched and now **drop** pymilvus/pandas/grpcio.
- **Milvus README**: document the opt-in install.
- **uv.lock**: regenerated — the `pymilvus` node is unchanged, just regrouped.

## Impact

Removes ~85MB (`pandas` + `grpcio`) from the production conserver and api images for the common case that doesn't use Milvus.

## ⚠️ Breaking change

Deployments using the Milvus storage backend must now install it explicitly:

```
uv sync --group storage --group storage-milvus
```

Without it, loading `storage.milvus` raises a clear `ImportError`. (This is the intended opt-in behavior — every other storage backend already imports its own driver this way; this just stops bundling the heavy one by default.)

## Testing

- `common/storage/milvus/` (both test files): **25 passed** with `pymilvus` present (tests run, not skipped — confirms `importorskip` doesn't break the running case).
- `common/`: 254 tests collect cleanly — no import errors from the regroup.
- `uv lock --check` passes (lock coherent with the regrouped manifest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)