### PR TITLE
ci: bump GitHub Actions to Node 24 runtimes

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -75,20 +75,20 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to Amazon ECR Public
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: public.ecr.aws
           username: ${{ secrets.AWS_ACCESS_KEY }}
           password: ${{ secrets.AWS_SECRET }}
 
       - name: Build and push ${{ matrix.service }} (${{ matrix.platform_tag }})
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ${{ matrix.dockerfile }}
@@ -118,10 +118,10 @@ jobs:
 
     steps:
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to Amazon ECR Public
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: public.ecr.aws
           username: ${{ secrets.AWS_ACCESS_KEY }}
@@ -161,7 +161,7 @@ jobs:
 
     steps:
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ github.ref_name }}
           name: Release ${{ github.ref_name }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
     # Step 1: Check out the repository
     - name: Check out the repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v6
 
     - name: Set up Docker
       run: |
@@ -39,7 +39,7 @@ jobs:
 
     - name: Upload coverage report
       if: always()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: coverage-report
         path: |


### PR DESCRIPTION
GitHub is forcing Node 20 JS actions onto Node 24 starting 2026-06-16, and removing Node 20 from runners on 2026-09-16 ([changelog](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)). The build/test workflows currently emit the Node 20 deprecation warning.

This bumps every affected action to its latest major release, each of which declares `runs.using: node24`:

| Action | From | To |
| --- | --- | --- |
| actions/checkout | v3 / v4 | v6 |
| actions/upload-artifact | v4 | v7 |
| docker/setup-buildx-action | v3 | v4 |
| docker/login-action | v3 | v4 |
| docker/build-push-action | v5 | v7 |
| softprops/action-gh-release | v1 | v3 |

No workflow logic changed — only action versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)