### PR TITLE
fix(docker): drop undefined $PYTHONPATH prefix in production Dockerfiles

### DIFF
--- a/docker/Dockerfile.api
+++ b/docker/Dockerfile.api
@@ -40,7 +40,7 @@ COPY common/ /app/common/
 COPY api/ /app/api/
 COPY docker/ /app/docker/
 
-ENV PYTHONPATH="${PYTHONPATH}:/app/:/app/common/:/app/api/"
+ENV PYTHONPATH="/app/:/app/common/:/app/api/"
 
 ENTRYPOINT ["/app/docker/wait_for_redis.sh"]
 CMD ["opentelemetry-instrument", "uvicorn", "api:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/docker/Dockerfile.conserver
+++ b/docker/Dockerfile.conserver
@@ -46,7 +46,7 @@ COPY common/ /app/common/
 COPY conserver/ /app/conserver/
 COPY docker/ /app/docker/
 
-ENV PYTHONPATH="${PYTHONPATH}:/app/:/app/common/:/app/conserver/"
+ENV PYTHONPATH="/app/:/app/common/:/app/conserver/"
 
 ENTRYPOINT ["/app/docker/wait_for_redis.sh"]
 CMD ["opentelemetry-instrument", "python", "/app/conserver/main.py"]


### PR DESCRIPTION
The api and conserver Dockerfiles set `PYTHONPATH` as `${PYTHONPATH}:/app/...`, but the base image (`python:3.12-slim`) never defines `PYTHONPATH`. BuildKit therefore emits an `UndefinedVar: Usage of undefined variable '$PYTHONPATH'` warning on every build, and the resulting value carries a stray leading colon (an empty path entry = current dir).

This drops the `${PYTHONPATH}:` prefix:

```diff
- ENV PYTHONPATH="${PYTHONPATH}:/app/:/app/common/:/app/api/"
+ ENV PYTHONPATH="/app/:/app/common/:/app/api/"
```

No behavior change: the listed directories are identical, and `/app` is already among them, so the implicit current-dir entry was redundant. The dev/test image (`docker/Dockerfile`) already uses this prefix-free form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)