### PR TITLE
Guard tag link against missing vCon (CON-617)

### DIFF
--- a/conserver/links/tag/__init__.py
+++ b/conserver/links/tag/__init__.py
@@ -16,6 +16,12 @@ def run(
 
     vcon_redis = VconRedis()
     vCon = vcon_redis.get_vcon(vcon_uuid)
+    if vCon is None:
+        # get_vcon returns None when the vCon is missing from Redis and every
+        # storage backend (evicted/expired under chain latency). None is the
+        # documented "halt the chain" contract, so stop rather than crash.
+        logger.warning(f"tag: vCon {vcon_uuid} not found, halting chain")
+        return None
     for tag in opts.get("tags", []):
         vCon.add_tag(tag_name=tag, tag_value=tag)
     vcon_redis.store_vcon(vCon)

--- a/conserver/links/tag/test_tag.py
+++ b/conserver/links/tag/test_tag.py
@@ -34,6 +34,19 @@ def test_run_respects_custom_tags(mock_vcon_redis):
 
 
 @patch("links.tag.VconRedis")
+def test_run_halts_chain_when_vcon_missing(mock_vcon_redis):
+    # Regression for CON-617: get_vcon returns None on a Redis/storage miss.
+    # The link must halt the chain, not crash with 'NoneType' has no add_tag.
+    mock_instance = mock_vcon_redis.return_value
+    mock_instance.get_vcon.return_value = None
+
+    result = run("missing-uuid", "tag")
+
+    assert result is None
+    mock_instance.store_vcon.assert_not_called()
+
+
+@patch("links.tag.VconRedis")
 def test_run_handles_empty_tag_list(mock_vcon_redis):
     vcon = Vcon.build_new()
     mock_instance = mock_vcon_redis.return_value


### PR DESCRIPTION
## Problem

The conserver `tag` link crashes with `'NoneType' object has no attribute 'add_tag'` and drops the vCon to the DLQ whenever `VconRedis.get_vcon(vcon_uuid)` returns `None`.

`get_vcon` (`common/lib/vcon_redis.py`) is typed `Optional[vcon.Vcon]` and its docstring states `None` is the documented "halt the chain" contract for conserver links (Redis miss with no storage hit). The `tag` link had no `None` guard and called `.add_tag` straight away.

On BDS this fired ~376k times between 2026-06-07 and 2026-06-09, peaking ~126k per 10 min during a chain-latency incident (p95 processing ~2.5h) — delayed vCons had expired/evicted from Redis by the time the lagging tag link reached them.

## Fix

Halt the chain on `None`, matching the existing `tag_router` link (`conserver/links/tag_router/__init__.py:40` already does `if not vcon: return None`).

```python
vCon = vcon_redis.get_vcon(vcon_uuid)
if vCon is None:
    logger.warning(f"tag: vCon {vcon_uuid} not found, halting chain")
    return None
```

## Test

Adds `test_run_halts_chain_when_vcon_missing` mocking `get_vcon` → `None`, asserting `run(...)` returns `None` and `store_vcon` is never called. The existing tests never mocked a `None` return, which is why this stayed green.

All 4 tag tests pass locally.

Linear: CON-617