### PR TITLE
fix(tag): tolerate dict-bodied tags attachment and apply name:value/dict options (CON-737)

### DIFF
--- a/common/vcon.py
+++ b/common/vcon.py
@@ -131,6 +131,14 @@ class Vcon:
         # back as spec-correct ``encoding=json`` + stringified list, per
         # draft-ietf-vcon-vcon-core-02 §2.3.2 (body is always a String).
         tags = self.decoded_body(tags_attachment) or []
+        if isinstance(tags, dict):
+            # A producer wrote purpose="tags" with a dict body (e.g. the SIPREC
+            # adapter's provenance metadata). Flatten to the tag convention's
+            # "name:value" list so get_tag reads it and append never raises.
+            # (CON-737)
+            tags = [f"{k}:{v}" for k, v in tags.items()]
+        elif not isinstance(tags, list):
+            tags = [tags]
         tags.append(f"{tag_name}:{tag_value}")
         tags_attachment["body"] = json.dumps(tags)
         tags_attachment["encoding"] = "json"

--- a/conserver/links/tag/__init__.py
+++ b/conserver/links/tag/__init__.py
@@ -16,8 +16,21 @@ def run(
 
     vcon_redis = VconRedis()
     vCon = vcon_redis.get_vcon(vcon_uuid)
-    for tag in opts.get("tags", []):
-        vCon.add_tag(tag_name=tag, tag_value=tag)
+    tags = opts.get("tags", [])
+    if isinstance(tags, dict):
+        # dict-form options: {name: value} (CON-737)
+        pairs = list(tags.items())
+    else:
+        # list-form options: "name:value" strings, or bare names.
+        pairs = []
+        for tag in tags:
+            if isinstance(tag, str) and ":" in tag:
+                name, value = tag.split(":", 1)
+            else:
+                name = value = tag
+            pairs.append((name, value))
+    for name, value in pairs:
+        vCon.add_tag(tag_name=name, tag_value=value)
     vcon_redis.store_vcon(vCon)
 
     # Return the vcon_uuid down the chain.

--- a/conserver/links/tag/test_tag.py
+++ b/conserver/links/tag/test_tag.py
@@ -1,3 +1,4 @@
+import json
 from unittest.mock import patch
 
 from vcon import Vcon
@@ -43,4 +44,49 @@ def test_run_handles_empty_tag_list(mock_vcon_redis):
 
     assert result == "test-uuid"
     assert vcon.get_tag("iron") is None
+    mock_instance.store_vcon.assert_called_once_with(vcon)
+
+
+@patch("links.tag.VconRedis")
+def test_run_applies_name_value_string_tags(mock_vcon_redis):
+    # "name:value" options must set name -> value, not "tag:tag". (CON-737)
+    vcon = Vcon.build_new()
+    mock_instance = mock_vcon_redis.return_value
+    mock_instance.get_vcon.return_value = vcon
+
+    run("test-uuid", "tag", opts={"tags": ["source:siprec-adapter", "pipeline:interop"]})
+
+    assert vcon.get_tag("source") == "siprec-adapter"
+    assert vcon.get_tag("pipeline") == "interop"
+
+
+@patch("links.tag.VconRedis")
+def test_run_applies_dict_form_tags(mock_vcon_redis):
+    # dict-form options: {name: value}. (CON-737)
+    vcon = Vcon.build_new()
+    mock_instance = mock_vcon_redis.return_value
+    mock_instance.get_vcon.return_value = vcon
+
+    run("test-uuid", "tag", opts={"tags": {"env": "prod", "team": "interop"}})
+
+    assert vcon.get_tag("env") == "prod"
+    assert vcon.get_tag("team") == "interop"
+
+
+@patch("links.tag.VconRedis")
+def test_run_tolerates_dict_bodied_tags_attachment(mock_vcon_redis):
+    # A producer (e.g. the SIPREC adapter) wrote purpose="tags" with a dict
+    # body. add_tag must flatten it instead of raising on `.append`. (CON-737)
+    vcon = Vcon.build_new()
+    vcon.vcon_dict["attachments"].append(
+        {"purpose": "tags", "encoding": "json", "body": json.dumps({"source": "siprec"})}
+    )
+    mock_instance = mock_vcon_redis.return_value
+    mock_instance.get_vcon.return_value = vcon
+
+    result = run("test-uuid", "tag", opts={"tags": ["pipeline:interop"]})
+
+    assert result == "test-uuid"
+    assert vcon.get_tag("source") == "siprec"      # pre-existing dict entry preserved
+    assert vcon.get_tag("pipeline") == "interop"   # new tag appended
     mock_instance.store_vcon.assert_called_once_with(vcon)


### PR DESCRIPTION
## Problem

The SIPREC -> conserver interop path (CON-737) DLQ'd every real vCon: the `siprec_provenance` link (`links.tag`) crashed with `AttributeError: 'dict' object has no attribute 'append'`, so nothing reached Postgres storage.

Two distinct defects:

1. **`add_tag` assumed a list body.** It did `tags = decoded_body(...); tags.append(...)`. The SIPREC adapter emits a `purpose:"tags"` attachment whose body is a **dict** of provenance metadata (`source`, `call_id`, `session_id`, ...), so `.append` raised and the vCon was DLQ'd before storage. A vCon with no prior tags attachment worked (fresh list), which is why it only bit real adapter traffic.

2. **The tag link doubled `name:value` options.** `run()` called `add_tag(tag_name=tag, tag_value=tag)`, so a configured `"source:siprec-adapter"` became the tag `"source:siprec-adapter:source:siprec-adapter"`.

## Fix

- `add_tag` flattens a dict body to the tag convention's `"name:value"` list (and coerces any other non-list body) before appending. Pre-existing dict entries are preserved as `k:v` tags and remain readable via `get_tag`.
- `links.tag` parses `"name:value"` option strings into `(name, value)` and also accepts **dict-form** options `{name: value}`. Bare names keep the existing `name:name` behavior.

## Tests

Adds 3 regression tests to `conserver/links/tag/test_tag.py` (name:value strings, dict-form options, dict-bodied existing attachment). Full file: 6 passed.

Verified live on the CON-737 interop conserver: after the fix, synthetic SIPREC calls flow adapter -> ingress -> `siprec_chain` -> Postgres with tags `["source:siprec", ..., "source:siprec-adapter", "pipeline:siprec-interop"]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)